### PR TITLE
fix(ebi): prevent deadlock when errorCh reader exits on ctx cancel

### DIFF
--- a/ebi.go
+++ b/ebi.go
@@ -141,6 +141,26 @@ func (ebi *EBI[T]) discoverWorkerNodes(ctx context.Context) (int, error) {
 	return dataNodes, nil
 }
 
+// asyncErrorSend sends err to errorCh without blocking if ctx is cancelled
+// or errorCh is nil. Returns true if the error was delivered, false if
+// ctx cancelled first or errorCh was nil.
+//
+// This is the deadlock-safe counterpart to a bare `errorCh <- err` send:
+// callers can signal an error asynchronously without risking a hang when
+// the reader goroutine has already exited (e.g. on context cancellation).
+func asyncErrorSend(ctx context.Context, errorCh chan<- error, err error) bool {
+	if errorCh == nil {
+		return false
+	}
+
+	select {
+	case errorCh <- err:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
 //////
 // Exported functionalities.
 //////
@@ -249,10 +269,13 @@ func (ebi *EBI[T]) BulkCreate(
 	//////
 
 	// Helper function to send async errors.
+	//
+	// Delegates to asyncErrorSend so the error send is ctx-aware — if the
+	// reader goroutine has already exited (e.g. on context cancellation)
+	// we won't deadlock on an unbuffered ErrorCh. See asyncErrorSend for
+	// the rationale and the production incident it guards against.
 	asyncErrorHandler := func(err error) {
-		if opts.ErrorCh != nil {
-			opts.ErrorCh <- err
-		}
+		_ = asyncErrorSend(ctx, opts.ErrorCh, err)
 	}
 
 	//////

--- a/utils.go
+++ b/utils.go
@@ -223,6 +223,12 @@ func process(v any) error {
 
 // HandleChannel is a generic function to handle a channel with a callback
 // function.
+//
+// The error send on errorCh is guarded by a select on ctx.Done() and doneCh
+// so the worker does not deadlock if the error-reader goroutine has already
+// exited (e.g. on context cancellation). If errorCh is nil, errors from
+// cbFunc are silently dropped rather than panicking or blocking forever on
+// a send-to-nil-channel.
 func HandleChannel[T any](
 	ctx context.Context,
 	workCh chan T,
@@ -239,7 +245,22 @@ func HandleChannel[T any](
 
 			if cbFunc != nil {
 				if err := cbFunc(t); err != nil {
-					errorCh <- err
+					// Silently drop if no error channel is configured.
+					// Matches the guard in asyncErrorSend and prevents a
+					// send-to-nil-channel hang.
+					if errorCh == nil {
+						continue
+					}
+
+					// Guard the error send so a cancelled context or a
+					// closed doneCh unblocks us if the reader is gone.
+					select {
+					case errorCh <- err:
+					case <-ctx.Done():
+						return
+					case <-doneCh:
+						return
+					}
 				}
 			}
 		case <-ctx.Done(): // Stop loop if context is done

--- a/utils_test.go
+++ b/utils_test.go
@@ -25,12 +25,14 @@ func TestHandleChannel_ErrorSendDoesNotDeadlockWhenReaderGone(t *testing.T) {
 	// Kill the error reader immediately to simulate the post-ctx-cancel state
 	// where the reader has already exited.
 	readerDone := make(chan struct{})
+
 	go func() {
 		// Reader that exits on ctx cancel (same pattern as UVS's error handler).
 		for {
 			select {
 			case <-ctx.Done():
 				close(readerDone)
+
 				return
 			case err := <-errorCh:
 				// Drop it — simulates early reader exit by not processing.
@@ -50,10 +52,12 @@ func TestHandleChannel_ErrorSendDoesNotDeadlockWhenReaderGone(t *testing.T) {
 	// With the fix, HandleChannel must return promptly (because ctx is already
 	// cancelled). Without the fix, the errorCh <- err send blocks forever.
 	workerDone := make(chan struct{})
+
 	go func() {
 		HandleChannel(ctx, workCh, errorCh, doneCh, func(_ int) error {
 			return errors.New("forced")
 		})
+
 		close(workerDone)
 	}()
 
@@ -75,16 +79,19 @@ func TestHandleChannel_NilErrorChDoesNotPanic(t *testing.T) {
 
 	workCh := make(chan int, 1)
 	workCh <- 1
+
 	close(workCh)
 
 	doneCh := make(chan struct{})
 
 	// No panic, no hang — even though cbFunc returns an error and errorCh is nil.
 	done := make(chan struct{})
+
 	go func() {
 		HandleChannel(ctx, workCh, nil, doneCh, func(_ int) error {
 			return errors.New("forced")
 		})
+
 		close(done)
 	}()
 
@@ -133,15 +140,18 @@ func TestHandleChannel_DoneChCancelsErrorSend(t *testing.T) {
 	doneCh := make(chan struct{})
 
 	workerDone := make(chan struct{})
+
 	go func() {
 		HandleChannel(ctx, workCh, errorCh, doneCh, func(_ int) error {
 			return errors.New("forced")
 		})
+
 		close(workerDone)
 	}()
 
 	// Close doneCh mid-stuck-send.
 	time.Sleep(50 * time.Millisecond) // let the worker get to the send.
+
 	close(doneCh)
 
 	select {
@@ -161,10 +171,13 @@ func TestAsyncErrorSend_DoesNotBlockOnCtxCancel(t *testing.T) {
 	errorCh := make(chan error) // unbuffered, no reader.
 
 	done := make(chan struct{})
+
 	go func() {
 		defer close(done)
+
 		// With ctx already cancelled this must return false quickly.
 		cancel()
+
 		if asyncErrorSend(ctx, errorCh, errors.New("forced")) {
 			t.Errorf("asyncErrorSend reported delivery when ctx was cancelled")
 		}
@@ -209,8 +222,10 @@ func TestAsyncErrorSend_NoPanicOnNilChannel(t *testing.T) {
 	defer cancel()
 
 	done := make(chan struct{})
+
 	go func() {
 		defer close(done)
+
 		if asyncErrorSend(ctx, nil, errors.New("forced")) {
 			t.Errorf("asyncErrorSend reported delivery on nil channel")
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,225 @@
+package ebi
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestHandleChannel_ErrorSendDoesNotDeadlockWhenReaderGone reproduces the
+// production deadlock observed 2026-04-17: an unbuffered errorCh where the
+// reader goroutine exits via ctx.Done() first, then the writer tries to
+// send an error. Without the ctx-aware select in the send, this hangs.
+//
+// The test asserts the work handler returns within a tight deadline instead
+// of blocking forever.
+func TestHandleChannel_ErrorSendDoesNotDeadlockWhenReaderGone(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errorCh := make(chan error) // UNBUFFERED — matches UVS usage.
+	workCh := make(chan int, 1)
+	doneCh := make(chan struct{})
+
+	// Kill the error reader immediately to simulate the post-ctx-cancel state
+	// where the reader has already exited.
+	readerDone := make(chan struct{})
+	go func() {
+		// Reader that exits on ctx cancel (same pattern as UVS's error handler).
+		for {
+			select {
+			case <-ctx.Done():
+				close(readerDone)
+				return
+			case err := <-errorCh:
+				// Drop it — simulates early reader exit by not processing.
+				_ = err
+			}
+		}
+	}()
+
+	// Send one work item that will make cbFunc return an error.
+	workCh <- 1
+
+	// Cancel ctx and wait for reader to exit BEFORE the worker tries to send.
+	cancel()
+	<-readerDone
+
+	// Now run HandleChannel as the work handler. Its cbFunc returns an error.
+	// With the fix, HandleChannel must return promptly (because ctx is already
+	// cancelled). Without the fix, the errorCh <- err send blocks forever.
+	workerDone := make(chan struct{})
+	go func() {
+		HandleChannel(ctx, workCh, errorCh, doneCh, func(_ int) error {
+			return errors.New("forced")
+		})
+		close(workerDone)
+	}()
+
+	select {
+	case <-workerDone:
+		// PASS — the handler unblocked on ctx.Done despite the dead reader.
+	case <-time.After(2 * time.Second):
+		t.Fatal("HandleChannel deadlocked on errorCh send after reader exited; " +
+			"the ctx-aware select fix is missing or broken")
+	}
+}
+
+// TestHandleChannel_NilErrorChDoesNotPanic verifies the nil errorCh guard.
+// A bare send on a nil channel blocks forever in Go; the guard must catch
+// that case.
+func TestHandleChannel_NilErrorChDoesNotPanic(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	workCh := make(chan int, 1)
+	workCh <- 1
+	close(workCh)
+
+	doneCh := make(chan struct{})
+
+	// No panic, no hang — even though cbFunc returns an error and errorCh is nil.
+	done := make(chan struct{})
+	go func() {
+		HandleChannel(ctx, workCh, nil, doneCh, func(_ int) error {
+			return errors.New("forced")
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("HandleChannel hung when errorCh was nil")
+	}
+}
+
+// TestHandleChannel_HappyPath_ForwardsError verifies the normal case still
+// works: cbFunc returns error → errorCh receives it.
+func TestHandleChannel_HappyPath_ForwardsError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	workCh := make(chan int, 1)
+	workCh <- 1
+
+	errorCh := make(chan error, 1) // buffered so we don't need a reader.
+	doneCh := make(chan struct{})
+
+	go HandleChannel(ctx, workCh, errorCh, doneCh, func(_ int) error {
+		return errors.New("forced")
+	})
+
+	select {
+	case err := <-errorCh:
+		if err == nil || err.Error() != "forced" {
+			t.Fatalf("expected forwarded error, got %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("error was not forwarded to errorCh")
+	}
+}
+
+// TestHandleChannel_DoneChCancelsErrorSend verifies that if doneCh closes
+// while we're trying to send an error, we exit cleanly (not deadlock).
+func TestHandleChannel_DoneChCancelsErrorSend(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errorCh := make(chan error) // unbuffered, no reader.
+	workCh := make(chan int, 1)
+	workCh <- 1
+	doneCh := make(chan struct{})
+
+	workerDone := make(chan struct{})
+	go func() {
+		HandleChannel(ctx, workCh, errorCh, doneCh, func(_ int) error {
+			return errors.New("forced")
+		})
+		close(workerDone)
+	}()
+
+	// Close doneCh mid-stuck-send.
+	time.Sleep(50 * time.Millisecond) // let the worker get to the send.
+	close(doneCh)
+
+	select {
+	case <-workerDone:
+		// PASS
+	case <-time.After(1 * time.Second):
+		t.Fatal("HandleChannel did not exit on doneCh close while errorCh send was pending")
+	}
+}
+
+// TestAsyncErrorSend_DoesNotBlockOnCtxCancel verifies the package-level
+// helper extracted from BulkCreate's asyncErrorHandler: with an unbuffered
+// errorCh and no reader, a cancelled ctx must unblock the send.
+func TestAsyncErrorSend_DoesNotBlockOnCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errorCh := make(chan error) // unbuffered, no reader.
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// With ctx already cancelled this must return false quickly.
+		cancel()
+		if asyncErrorSend(ctx, errorCh, errors.New("forced")) {
+			t.Errorf("asyncErrorSend reported delivery when ctx was cancelled")
+		}
+	}()
+
+	select {
+	case <-done:
+		// PASS
+	case <-time.After(1 * time.Second):
+		t.Fatal("asyncErrorSend did not return after ctx cancel with dead reader")
+	}
+}
+
+// TestAsyncErrorSend_DeliversWhenReaderPresent verifies the happy path: a
+// live reader receives the error and the helper reports delivered=true.
+func TestAsyncErrorSend_DeliversWhenReaderPresent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errorCh := make(chan error, 1) // buffered so the send completes.
+
+	delivered := asyncErrorSend(ctx, errorCh, errors.New("forced"))
+	if !delivered {
+		t.Fatal("asyncErrorSend reported non-delivery with a ready reader")
+	}
+
+	select {
+	case err := <-errorCh:
+		if err == nil || err.Error() != "forced" {
+			t.Fatalf("expected forwarded error, got %v", err)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("error not received on errorCh")
+	}
+}
+
+// TestAsyncErrorSend_NoPanicOnNilChannel verifies the nil guard — a naive
+// `errorCh <- err` on a nil channel blocks forever in Go, so the guard is
+// load-bearing.
+func TestAsyncErrorSend_NoPanicOnNilChannel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if asyncErrorSend(ctx, nil, errors.New("forced")) {
+			t.Errorf("asyncErrorSend reported delivery on nil channel")
+		}
+	}()
+
+	select {
+	case <-done:
+		// PASS
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("asyncErrorSend hung on nil channel")
+	}
+}


### PR DESCRIPTION
## Summary

Two blocking error-channel sends (`utils.go:HandleChannel` and `ebi.go:BulkCreate.asyncErrorHandler`) lacked a ctx escape. When the error-reader goroutine exited first via `<-ctx.Done()`, the sender hung forever on an unbuffered `errorCh`.

## Production incident — 2026-04-17

Ringboost UVS (which uses ebi) suffered a deadlock during a scheduled import:
- A 6h orchestration context fired (`ImporterMaxRotationDuration` timeout).
- UVS's error-handler goroutine (reading from an **unbuffered** `errorCh`) returned on `<-ctx.Done()`.
- `BulkCreate`'s async callback path then emitted an error and blocked on `opts.ErrorCh <- err` forever.
- The orchestrator goroutine stayed stuck 2h+ holding an SQS message and blocking the next scheduled import.
- Required manual SQS purge + ECS stop-task.

## Fix

**`utils.go:HandleChannel`** — wrap the `errorCh <- err` in a `select` on `ctx.Done()` and `doneCh`, and short-circuit when `errorCh == nil` (matches the guard in `asyncErrorSend` and avoids a send-to-nil-channel hang).

**`ebi.go:BulkCreate.asyncErrorHandler`** — extract the send into a package-level helper `asyncErrorSend(ctx, errorCh, err)` that:
- returns early if `errorCh == nil`,
- races the send against `ctx.Done()`,
- returns a bool indicating delivery (for testability).

The closure in `BulkCreate` now delegates to this helper, which keeps the hot path identical while making the behaviour directly unit-testable without a mock Elasticsearch.

## Tests

7 new tests in `utils_test.go`, all using `-race`:

- `TestHandleChannel_ErrorSendDoesNotDeadlockWhenReaderGone` — reproduces the exact production scenario (unbuffered `errorCh`, reader exits on `ctx.Done()`, worker tries to send). Fails without the fix (hangs until the 2s deadline).
- `TestHandleChannel_DoneChCancelsErrorSend` — verifies `doneCh` close also unblocks a pending send.
- `TestHandleChannel_NilErrorChDoesNotPanic` — verifies the nil guard.
- `TestHandleChannel_HappyPath_ForwardsError` — regression guard for the happy path.
- `TestAsyncErrorSend_DoesNotBlockOnCtxCancel` — same deadlock check at the helper level.
- `TestAsyncErrorSend_DeliversWhenReaderPresent` — happy path for the helper.
- `TestAsyncErrorSend_NoPanicOnNilChannel` — nil guard for the helper.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -timeout 30s ./...` — full suite passes, new tests pass
- [x] Existing integration tests remain `t.Skip()` (no local ES), behaviour unchanged
- [ ] Downstream bump in Ringboost UVS (follow-up PR v2.0.95 will add defense-in-depth)

## Notes

- Lint via `make ci` is broken on both `main` and this branch due to a pre-existing golangci-lint config incompatibility (v1.61 config vs. v2.8 installed) — not touched in this PR.
- The `for _, doc := range docs { defer ... }` at `ebi.go:422` is a separate memory concern (N allocated defer frames). Left untouched per the scope of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)