### PR TITLE
fix(bulkoptions): validate non-empty sampleDoc, fail-fast on construction

### DIFF
--- a/bulkoptions.go
+++ b/bulkoptions.go
@@ -281,6 +281,18 @@ func WithDocAsUpsert[T any](docAsUpsert bool) BulkOptionsFunc[T] {
 
 // NewBulkOptions calculates the bulk indexing options based on the
 // sample document size and cluster configuration.
+//
+// sampleDoc MUST be a non-empty JSON document — its byte length is used
+// later in BulkCreate to compute the recommended batch size
+// (`targetBatchSizeBytes / docSize` in ebi.go). Passing a zero-length
+// sampleDoc would surface as `runtime error: integer divide by zero`
+// inside BulkCreate, far from the construction site, with no error
+// return path. Fail fast here with a clear, named error instead.
+//
+// The struct's `validate:"required"` tag on SampleDoc does NOT catch this
+// case: an empty (but non-nil) `json.RawMessage([]byte{})` satisfies the
+// `required` validator because it's a non-nil slice. This explicit length
+// check is the only safety net against the panic.
 func NewBulkOptions[T any](
 	// Index name.
 	indexName string,
@@ -290,6 +302,14 @@ func NewBulkOptions[T any](
 
 	options ...BulkOptionsFunc[T],
 ) (*BulkOptions[T], error) {
+	//////
+	// Required-input validation (fail fast — see doc comment).
+	//////
+
+	if len(sampleDoc) == 0 {
+		return nil, ErrorCatalog.MustGet(ErrSampleDocRequired).NewRequiredError()
+	}
+
 	//////
 	// Apply options.
 	//////

--- a/bulkoptions_test.go
+++ b/bulkoptions_test.go
@@ -16,3 +16,48 @@ func TestNewBulkOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, got)
 }
+
+// TestNewBulkOptions_EmptySampleDoc_ReturnsError pins a regression that hit
+// the UVS project (proj-ringboost-vendor) on 2026-04-22. A caller passed
+// json.RawMessage("") as the sampleDoc; ebi happily constructed BulkOptions
+// and only panicked later inside BulkCreate at
+// `targetBatchSizeBytes / docSize` in ebi.go (docSize = 0). The panic
+// surfaced as `runtime error: integer divide by zero`, was caught by the
+// caller's goroutine recover, and turned into a Failed task with no
+// surfaced error message.
+//
+// NewBulkOptions now fails fast with ErrSampleDocRequired so callers get a
+// clear, named error at the construction site.
+func TestNewBulkOptions_EmptySampleDoc_ReturnsError(t *testing.T) {
+	cases := []struct {
+		name      string
+		sampleDoc json.RawMessage
+	}{
+		{"nil RawMessage", nil},
+		{"empty bytes RawMessage", json.RawMessage{}},
+		{"empty string cast to RawMessage", json.RawMessage("")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewBulkOptions[*TestModel]("index", tc.sampleDoc)
+
+			assert.Error(t, err, "empty sampleDoc must return an error, not panic later inside BulkCreate")
+			assert.Nil(t, got)
+			assert.Contains(t, err.Error(), "sample document",
+				"error should reference the missing input by name so callers can self-diagnose")
+		})
+	}
+}
+
+// TestNewBulkOptions_NonEmptySampleDoc_NoError keeps the happy path covered
+// alongside the new validation.
+func TestNewBulkOptions_NonEmptySampleDoc_NoError(t *testing.T) {
+	got, err := NewBulkOptions[*TestModel](
+		"index",
+		json.RawMessage(`{"id":"x"}`),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+}

--- a/errorcatalog.go
+++ b/errorcatalog.go
@@ -32,6 +32,7 @@ const (
 	ErrInvalidBulkOptions               = "ERR_INVALID_BULK_OPTIONS"                   // Invalid.
 	ErrInvalidMetrics                   = "ERR_INVALID_METRICS"                        // Invalid.
 	ErrInvalidOperation                 = "ERR_INVALID_OPERATION"                      // Invalid.
+	ErrSampleDocRequired                = "ERR_SAMPLE_DOC_REQUIRED"                    // Required.
 )
 
 // ErrorCatalog is the error catalog for the EBI package.
@@ -58,7 +59,8 @@ var ErrorCatalog = customerror.
 	MustSet(ErrIndexNameRequired, "index name").
 	MustSet(ErrInvalidBulkOptions, "bulk options").
 	MustSet(ErrInvalidMetrics, "metrics").
-	MustSet(ErrInvalidOperation, "operation")
+	MustSet(ErrInvalidOperation, "operation").
+	MustSet(ErrSampleDocRequired, "sample document")
 
 //////
 // Exported functionalities.


### PR DESCRIPTION
## Summary

\`NewBulkOptions\` accepted a zero-length \`sampleDoc\` without complaint; the bug only surfaced inside \`BulkCreate\` at:

\`\`\`go
recommendedBatchSize := targetBatchSizeBytes / docSize  // ebi.go:239
\`\`\`

where \`docSize := len(opts.SampleDoc)\` (ebi.go:234) — division by zero, panic, far from the construction site, with no error return path.

The struct's \`validate:\"required\"\` tag on \`SampleDoc\` does **not** catch this case: an empty (but non-nil) \`json.RawMessage([]byte{})\` satisfies the \`required\` validator because it's a non-nil slice.

This PR adds an explicit length check at the very top of \`NewBulkOptions\` and returns \`ErrSampleDocRequired\` (new error code) so callers get a clear, named error at the construction site.

### Real-world incident

Discovered 2026-04-22 by the UVS project (proj-ringboost-vendor). A new tollfree-importer code path passed \`json.RawMessage(\"\")\` as the sample. Production v2.0.100 Tasks transitioned to \`Failed\` silently — the panic was caught by a goroutine recover in UVS but produced **no operator-visible error**.

UVS shipped a local hotfix (v2.0.101) by passing the proper package \`Sample\` template. This upstream fix prevents the same trap for every other ebi consumer.

## Test plan

- [x] \`go test ./... -run TestNewBulkOptions\` — all green:
  - \`TestNewBulkOptions\` (existing happy path, unchanged)
  - \`TestNewBulkOptions_EmptySampleDoc_ReturnsError\` — 3 sub-cases: nil, empty bytes, empty-string cast
  - \`TestNewBulkOptions_NonEmptySampleDoc_NoError\` — explicit happy-path coverage alongside the new validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)