### PR TITLE
fix(ebi): eliminate deadlocks, data races, panics, and dead options in BulkCreate

### DIFF
--- a/bulkoptions.go
+++ b/bulkoptions.go
@@ -36,7 +36,11 @@ type NumWorkersFunc func() (int, error)
 // NumWorkersByJVM calculates the number of workers based on the JVM heap size.
 func NumWorkersByJVM(metrics *Metrics) NumWorkersFunc {
 	return func() (int, error) {
-		jvmHeapSizeGB := float64(metrics.ramPerNodeGB) / 2
+		// Read through the locked getter — the metrics goroutine updates
+		// the node topology concurrently.
+		_, ramPerNodeGB := metrics.getNodeInfo()
+
+		jvmHeapSizeGB := float64(ramPerNodeGB) / 2
 
 		workersPerNode := int(jvmHeapSizeGB / 1)
 
@@ -84,17 +88,32 @@ type BulkOptions[T any] struct {
 	// Metrics related.
 	MetricsCheck time.Duration `default:"5s" json:"metricsCheck" validate:"required"`
 
+	// MetricsCh receives point-in-time snapshots of the metrics.
+	//
+	// NOTE: Delivery is best-effort: when the channel is full — or nobody
+	// is reading — snapshots are DROPPED rather than blocking the indexing
+	// workers. Buffer the channel to reduce drops. Do not close it while a
+	// bulk operation may still be running.
 	MetricsCh chan<- *Metrics
 
 	// Async error handling.
+	//
+	// NOTE: Unlike MetricsCh, error delivery blocks until the reader
+	// receives it (or the operation's context ends) — keep reading until
+	// BulkCreate returns, and do not close the channel while a bulk
+	// operation may still be running.
 	ErrorCh chan<- error
 
 	// Internals related.
-	FlushBytes     int           `json:"flushBytes" validate:"omitempty,gt=0"`
-	FlushInterval  time.Duration `default:"30s"     json:"flushInterval"      validate:"omitempty,gt=0"`
-	Index          string        `json:"index"      validate:"required"`
-	RefreshPolicy  RefreshPolicy `default:"false"   json:"refreshPolicy"      validate:"omitempty,oneof=false immediate wait_for"`
-	RetryOnFailure int           `default:"3"       json:"retryOnFailure"     validate:"omitempty,gte=0"`
+	FlushBytes    int           `json:"flushBytes" validate:"omitempty,gt=0"`
+	FlushInterval time.Duration `default:"30s"     json:"flushInterval"      validate:"omitempty,gt=0"`
+	Index         string        `json:"index"      validate:"required"`
+	RefreshPolicy RefreshPolicy `default:"false" json:"refreshPolicy" validate:"omitempty,oneof=false immediate wait_for"`
+
+	// RetryOnFailure is reserved: it is currently NOT wired into the
+	// underlying esutil.BulkIndexer (which has no per-item retry knob —
+	// retries are a client/transport concern).
+	RetryOnFailure int `default:"3" json:"retryOnFailure" validate:"omitempty,gte=0"`
 
 	//////
 	// Dynamic options, they are optional.
@@ -118,11 +137,17 @@ type BulkOptions[T any] struct {
 	Operation string `default:"index" json:"operation" validate:"omitempty"`
 
 	// DocAsUpsert determines whether to use upsert behavior for update
-	// operations. Default to `true` - if the document doesn't exist, it will be
-	// created.
+	// operations. NewBulkOptions defaults it to `true` - if the document
+	// doesn't exist, it will be created. Struct-literal construction gets
+	// the Go zero value (false).
 	//
 	// NOTE: It only applies to `update` "Operation".
-	DocAsUpsert bool `default:"true" json:"docAsUpsert"`
+	DocAsUpsert bool `json:"docAsUpsert"`
+
+	// docAsUpsertSet records whether WithDocAsUpsert was used: without it,
+	// NewBulkOptions cannot tell an explicit `false` apart from "not set"
+	// and would clobber it with the default `true`.
+	docAsUpsertSet bool
 
 	// RoutingFunc determines in the evaluation time the routing value.
 	RoutingFunc func(doct T) string `json:"-"`
@@ -272,6 +297,7 @@ func WithOperation[T any](operation string) BulkOptionsFunc[T] {
 func WithDocAsUpsert[T any](docAsUpsert bool) BulkOptionsFunc[T] {
 	return func(o *BulkOptions[T]) {
 		o.DocAsUpsert = docAsUpsert
+		o.docAsUpsertSet = true
 	}
 }
 
@@ -321,11 +347,22 @@ func NewBulkOptions[T any](
 		option(&opts)
 	}
 
+	// DocAsUpsert defaults to true, but an explicit WithDocAsUpsert wins —
+	// including WithDocAsUpsert(false), which a `default` tag would clobber
+	// back to true (zero value == "unset" for the tag processor).
+	docAsUpsert := true
+	if opts.docAsUpsertSet {
+		docAsUpsert = opts.DocAsUpsert
+	}
+
 	bO := &BulkOptions[T]{
 		Index:     indexName,
 		SampleDoc: sampleDoc,
 
 		Operation: opts.Operation,
+
+		DocAsUpsert:    docAsUpsert,
+		docAsUpsertSet: true,
 
 		RefreshPolicy: opts.RefreshPolicy,
 

--- a/bulkoptions.go
+++ b/bulkoptions.go
@@ -75,8 +75,6 @@ func NumWorkersAutoDiscovery[T any](ctx context.Context, ebi *EBI[T]) NumWorkers
 // BulkOptions defines the options for bulk indexing.
 //
 // NOTE: Use NewBulkOptions() to create a new BulkOptions struct!
-//
-//nolint:lll
 type BulkOptions[T any] struct {
 	// These are options that can be used in the hyperparameter tuning.
 	BatchSize  int            `json:"batchSize"`
@@ -108,6 +106,9 @@ type BulkOptions[T any] struct {
 	FlushBytes    int           `json:"flushBytes" validate:"omitempty,gt=0"`
 	FlushInterval time.Duration `default:"30s"     json:"flushInterval"      validate:"omitempty,gt=0"`
 	Index         string        `json:"index"      validate:"required"`
+
+	// RefreshPolicy controls the refresh query parameter sent on each bulk
+	// request ("immediate" maps to refresh=true).
 	RefreshPolicy RefreshPolicy `default:"false" json:"refreshPolicy" validate:"omitempty,oneof=false immediate wait_for"`
 
 	// RetryOnFailure is reserved: it is currently NOT wired into the

--- a/ebi.go
+++ b/ebi.go
@@ -41,11 +41,13 @@ const (
 	Delete = "delete"
 )
 
-// PauseFunc determines the conditions to pause the indexing process.
+// PauseFunc determines the conditions to pause the indexing process. It
+// receives a point-in-time snapshot of the metrics.
 type PauseFunc func(metrics *Metrics) bool
 
 // RefreshFunc determines the conditions to refresh the index. A good metric
-// for that is the TranslogSize.
+// for that is the TranslogSize. It receives a point-in-time snapshot of the
+// metrics.
 type RefreshFunc func(ctx context.Context, metrics *Metrics) bool
 
 // EBI (Elasticsearch Bulk Indexer) is a generic struct that provides efficient
@@ -108,6 +110,15 @@ func (ebi *EBI[T]) retrieveNodeStats(ctx context.Context, metrics ...string) (*N
 
 	defer nodesStats.Body.Close()
 
+	// An HTTP error payload (401/403/500...) would happily decode into a
+	// zero NodesStats — 0 data nodes, bogus pressure, silently wrong
+	// worker counts — so it must be rejected here.
+	if nodesStats.IsError() {
+		return nil, ErrorCatalog.
+			MustGet(ErrFailedToGetNodeStats).
+			NewFailedToError(customerror.WithField("response", nodesStats.String()))
+	}
+
 	var nodesStatsResp NodesStats
 	if err := json.NewDecoder(nodesStats.Body).Decode(&nodesStatsResp); err != nil {
 		return nil, ErrorCatalog.
@@ -133,12 +144,33 @@ func (ebi *EBI[T]) discoverWorkerNodes(ctx context.Context) (int, error) {
 	dataNodes := 0
 
 	for _, node := range ns.Nodes {
+		// A null node entry decodes into a nil pointer.
+		if node == nil {
+			continue
+		}
+
 		if strings.Contains(strings.Join(node.Roles, ","), "data") {
 			dataNodes++
 		}
 	}
 
 	return dataNodes, nil
+}
+
+// bestEffortMetricsSend sends a point-in-time snapshot of metrics to ch
+// without ever blocking: metrics are periodic telemetry, so when the
+// buffer is full (or nobody is reading) dropping the snapshot is always
+// preferable to stalling an indexing worker. Sending a snapshot (not the
+// live *Metrics) keeps receivers race-free while writers keep mutating.
+func bestEffortMetricsSend(ch chan<- *Metrics, m *Metrics) {
+	if ch == nil {
+		return
+	}
+
+	select {
+	case ch <- m.GetMetrics():
+	default:
+	}
 }
 
 // asyncErrorSend sends err to errorCh without blocking if ctx is cancelled
@@ -197,10 +229,34 @@ func (ebi *EBI[T]) BulkCreate(
 			NewRequiredError()
 	}
 
-	// Process.
+	// Options.
+	if opts == nil {
+		return ErrorCatalog.
+			MustGet(ErrInvalidBulkOptions).
+			NewRequiredError()
+	}
+
+	// Process a private shallow copy: process() applies `default` tags by
+	// WRITING into zero fields, and BulkCreate treats the caller's opts as
+	// read-only — it may be reused across calls or shared between
+	// concurrent calls (see the derived-settings note below).
+	optsCopy := *opts
+	opts = &optsCopy
+
 	if err := process(opts); err != nil {
 		return ErrorCatalog.
 			MustGet(ErrInvalidBulkOptions).
+			NewInvalidError(customerror.WithError(err))
+	}
+
+	// NewBulkOptions rejects empty sample docs, but BulkCreate also
+	// accepts caller-constructed struct literals — and the
+	// `validate:"required"` tag passes for an empty-but-non-nil
+	// json.RawMessage. Guard explicitly: SampleDoc's length is the divisor
+	// of the batch-size calculation below (0 => divide-by-zero panic).
+	if len(opts.SampleDoc) == 0 {
+		return ErrorCatalog.
+			MustGet(ErrSampleDocRequired).
 			NewRequiredError()
 	}
 
@@ -227,7 +283,12 @@ func (ebi *EBI[T]) BulkCreate(
 	}
 
 	//////
-	// Calculate recommended number of workers.
+	// Derived settings.
+	//
+	// NOTE: BulkCreate never writes back to opts: callers reuse the same
+	// BulkOptions across calls (HyperparameterOptimization does exactly
+	// that) and may share it between concurrent BulkCreate calls, so opts
+	// is treated as read-only here — every derived value lives in a local.
 	//////
 
 	// Calculate the size of the sample document.
@@ -242,14 +303,26 @@ func (ebi *EBI[T]) BulkCreate(
 		recommendedBatchSize = 1
 	}
 
-	// Set batch size.
-	if opts.BatchSize == 0 {
-		opts.BatchSize = roundToNearestThousandDivisibleBy2(recommendedBatchSize)
+	// FlushBytes: the caller's value; else one caller-batch worth of bytes
+	// — so a caller-set BatchSize drives the flush cadence; else the
+	// recommendation (~ the 5MB target). The UNROUNDED recommendation is
+	// used on purpose: rounding the min-1 clamp up to thousands would turn
+	// an oversized sample doc (> target) into a multi-GB flush buffer.
+	flushBytes := opts.FlushBytes
+	if flushBytes <= 0 {
+		if opts.BatchSize > 0 {
+			flushBytes = opts.BatchSize * docSize
+		} else {
+			flushBytes = recommendedBatchSize * docSize
+		}
 	}
 
 	// Calculate the number of workers based on the JVM heap size.
-	if opts.NumWorkers == nil {
-		jvmHeapSizeGB := float64(metrics.ramPerNodeGB) / 2
+	numWorkersFn := opts.NumWorkers
+	if numWorkersFn == nil {
+		numDataNodes, ramPerNodeGB := metrics.getNodeInfo()
+
+		jvmHeapSizeGB := float64(ramPerNodeGB) / 2
 
 		workersPerNode := int(jvmHeapSizeGB / 1)
 
@@ -257,41 +330,25 @@ func (ebi *EBI[T]) BulkCreate(
 			workersPerNode = 1
 		}
 
-		// Set number of workers.
-		opts.NumWorkers = NumWorkersManual(metrics.numDataNodes * workersPerNode)
-	}
-
-	// Set FlushBytes size.
-	opts.FlushBytes = recommendedBatchSize * docSize
-
-	//////
-	// Internal helper.
-	//////
-
-	// Helper function to send async errors.
-	//
-	// Delegates to asyncErrorSend so the error send is ctx-aware — if the
-	// reader goroutine has already exited (e.g. on context cancellation)
-	// we won't deadlock on an unbuffered ErrorCh. See asyncErrorSend for
-	// the rationale and the production incident it guards against.
-	asyncErrorHandler := func(err error) {
-		_ = asyncErrorSend(ctx, opts.ErrorCh, err)
+		numWorkersFn = NumWorkersManual(numDataNodes * workersPerNode)
 	}
 
 	//////
 	// Final index name definition.
 	//////
 
-	// Modify the index name if a function is provided.
-	if opts.IndexNameFunc != nil {
-		indexName := opts.IndexNameFunc(opts.Index)
+	// Modify the index name if a function is provided. The result stays
+	// local: writing it back to opts.Index would compound the suffix on
+	// every reuse of the same opts.
+	indexName := opts.Index
 
-		if indexName != "" {
-			opts.Index = indexName
+	if opts.IndexNameFunc != nil {
+		if name := opts.IndexNameFunc(indexName); name != "" {
+			indexName = name
 		}
 	}
 
-	if opts.Index == "" {
+	if indexName == "" {
 		return ErrorCatalog.
 			MustGet(ErrIndexNameRequired).
 			NewRequiredError()
@@ -301,65 +358,16 @@ func (ebi *EBI[T]) BulkCreate(
 	// Number of worker nodes determination.
 	//////
 
-	ns, err := opts.NumWorkers()
+	ns, err := numWorkersFn()
 	if err != nil {
 		return ErrorCatalog.
 			MustGet(ErrFailedToRetrieveNumWorkers).
-			NewRequiredError()
+			NewFailedToError(customerror.WithError(err))
 	}
 
 	//////
-	// BI Setup.
+	// Internal helpers.
 	//////
-
-	// Configure Bulk Indexer (BI).
-	bi, err := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
-		Client:        ebi.client,
-		Index:         opts.Index,
-		NumWorkers:    ns,
-		FlushBytes:    opts.FlushBytes,
-		FlushInterval: opts.FlushInterval,
-		OnError: func(_ context.Context, err error) {
-			defer func() {
-				// Ensures metrics channel is updated.
-				if opts.MetricsCh != nil {
-					opts.MetricsCh <- metrics
-				}
-			}()
-
-			// Update metrics.
-			metrics.IncrementErrorCount()
-
-			// Send this async error to the error channel.
-			asyncErrorHandler(
-				ErrorCatalog.
-					MustGet(ErrIndexerError).
-					NewFailedToError(
-						customerror.WithError(err),
-						customerror.WithTag("esutil.NewBulkIndexer.OnError"),
-					),
-			)
-		},
-	})
-	if err != nil {
-		return ErrorCatalog.
-			MustGet(ErrFailedToCreateBulkIndexer).
-			NewFailedToError(
-				customerror.WithError(err),
-				customerror.WithTag("esutil.NewBulkIndexer"),
-			)
-	}
-
-	defer bi.Close(ctx)
-
-	//////
-	// Metrics monitoring goroutine.
-	//////
-
-	// Start metrics monitoring goroutine.
-	metricsTicker := time.NewTicker(opts.MetricsCheck)
-
-	defer metricsTicker.Stop()
 
 	// metricsCtx is an INTERNAL context that fires Done() exactly when
 	// BulkCreate returns (via the deferred metricsCancel below). This
@@ -382,21 +390,121 @@ func (ebi *EBI[T]) BulkCreate(
 	metricsCtx, metricsCancel := context.WithCancel(ctx)
 	defer metricsCancel()
 
+	// Helper function to send async errors.
+	//
+	// Delegates to asyncErrorSend so the error send is ctx-aware — if the
+	// reader goroutine has already exited (e.g. on context cancellation)
+	// we won't deadlock on an unbuffered ErrorCh. Bound to metricsCtx, NOT
+	// the caller's ctx: with a Background-like caller ctx and a dead
+	// ErrorCh reader, a send guarded only by the caller's ctx would park
+	// its goroutine forever even after BulkCreate returned.
+	asyncErrorHandler := func(err error) {
+		_ = asyncErrorSend(metricsCtx, opts.ErrorCh, err)
+	}
+
+	//////
+	// BI Setup.
+	//////
+
+	// The ES bulk API accepts "true"/"false"/"wait_for" for refresh; the
+	// exported RefreshPolicyImmediate constant is "immediate", so map it.
+	refresh := opts.RefreshPolicy
+	if refresh == RefreshPolicyImmediate {
+		refresh = "true"
+	}
+
+	// Configure Bulk Indexer (BI).
+	bi, err := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
+		Client:        ebi.client,
+		Index:         indexName,
+		NumWorkers:    ns,
+		FlushBytes:    flushBytes,
+		FlushInterval: opts.FlushInterval,
+		Refresh:       refresh,
+		OnFlushStart:  opts.FlushStartFunc,
+		OnFlushEnd:    opts.FlushEndFunc,
+		OnError: func(_ context.Context, err error) {
+			// Update metrics.
+			metrics.IncrementErrorCount()
+
+			// Send this async error to the error channel.
+			asyncErrorHandler(
+				ErrorCatalog.
+					MustGet(ErrIndexerError).
+					NewFailedToError(
+						customerror.WithError(err),
+						customerror.WithTag("esutil.NewBulkIndexer.OnError"),
+					),
+			)
+
+			// This callback runs on an esutil worker goroutine — it must
+			// never block on a slow/absent metrics reader.
+			bestEffortMetricsSend(opts.MetricsCh, metrics)
+		},
+	})
+	if err != nil {
+		return ErrorCatalog.
+			MustGet(ErrFailedToCreateBulkIndexer).
+			NewFailedToError(
+				customerror.WithError(err),
+				customerror.WithTag("esutil.NewBulkIndexer"),
+			)
+	}
+
+	// esutil's Close closes the internal queue channel, so a second Close
+	// panics — closeBI makes it idempotent (touched only from this
+	// goroutine, no lock needed). The main path closes explicitly BEFORE
+	// reading Stats() so failures from the final flush are counted; the
+	// deferred call below only covers early-return paths.
+	biClosed := false
+
+	closeBI := func() error {
+		if biClosed {
+			return nil
+		}
+
+		biClosed = true
+
+		return bi.Close(ctx)
+	}
+
+	defer func() {
+		// Cancelling the metrics context BEFORE closing is load-bearing
+		// on error paths: Close blocks until the workers flush, and the
+		// worker callbacks' error sends are guarded by metricsCtx — with
+		// it cancelled they can never hang this return.
+		metricsCancel()
+
+		// Best-effort close: the main path already closed and consumed
+		// the error; here an error is already being returned.
+		_ = closeBI()
+	}()
+
+	//////
+	// Metrics monitoring goroutine.
+	//////
+
+	// Start metrics monitoring goroutine. It exits via metricsCtx (see
+	// its comment above) when BulkCreate returns.
+	metricsTicker := time.NewTicker(opts.MetricsCheck)
+
+	defer metricsTicker.Stop()
+
 	go func() {
 		for {
 			select {
 			case <-metricsCtx.Done():
 				return
 			case <-metricsTicker.C:
-				defer func() {
-					// Ensures metrics channel is updated.
-					if opts.MetricsCh != nil {
-						opts.MetricsCh <- metrics
-					}
-				}()
-
 				// Update ES metrics by updating `metrics`.
-				if err := updateIndexMetrics(ctx, ebi, metrics); err != nil {
+				//
+				// NOTE: The goroutine's ES calls run under metricsCtx (not
+				// the caller's ctx) so metricsCancel can interrupt an
+				// in-flight request once BulkCreate returns. Errors caused
+				// by that wind-down cancellation are suppressed — they are
+				// not indexing failures.
+				if err := updateIndexMetrics(metricsCtx, ebi, metrics); err != nil &&
+					metricsCtx.Err() == nil {
 					// Send this async error to the error channel.
 					asyncErrorHandler(
 						ErrorCatalog.
@@ -408,9 +516,14 @@ func (ebi *EBI[T]) BulkCreate(
 					)
 				}
 
+				// Point-in-time snapshot for the user callbacks: handing
+				// them the live *Metrics would let their field reads race
+				// with the esutil worker callbacks mutating it.
+				tickMetrics := metrics.GetMetrics()
+
 				// Determine if we should pause the bulk indexer.
 				if opts.PauseFunc != nil {
-					if opts.PauseFunc(metrics) {
+					if opts.PauseFunc(tickMetrics) {
 						// Pause if conditions are met.
 						metrics.UpdateStatus(StatusPaused)
 					} else {
@@ -420,8 +533,9 @@ func (ebi *EBI[T]) BulkCreate(
 				}
 
 				// Determine if we should refresh the index.
-				if opts.RefreshFunc != nil && opts.RefreshFunc(ctx, metrics) {
-					if err := ebi.refreshIndex(ctx, opts.Index); err != nil {
+				if opts.RefreshFunc != nil && opts.RefreshFunc(metricsCtx, tickMetrics) {
+					if err := ebi.refreshIndex(metricsCtx, indexName); err != nil &&
+						metricsCtx.Err() == nil {
 						// Send this async error to the error channel.
 						asyncErrorHandler(
 							ErrorCatalog.
@@ -433,6 +547,12 @@ func (ebi *EBI[T]) BulkCreate(
 						)
 					}
 				}
+
+				// Per-tick metrics delivery. Best-effort and inline —
+				// deferring these sends would accumulate one per tick and
+				// fire them all at goroutine exit, parking the goroutine
+				// forever when nobody reads the channel.
+				bestEffortMetricsSend(opts.MetricsCh, metrics)
 			}
 		}
 	}()
@@ -441,13 +561,6 @@ func (ebi *EBI[T]) BulkCreate(
 	//
 	// NOTE: This is a parallel, asynchronous, efficient indexing process.
 	for _, doc := range docs {
-		defer func() {
-			// Ensures metrics channel is updated.
-			if opts.MetricsCh != nil {
-				opts.MetricsCh <- metrics
-			}
-		}()
-
 		// Breaks the loop if the context errored by any reason.
 		if err := ctx.Err(); err != nil {
 			return ErrorCatalog.
@@ -516,17 +629,16 @@ func (ebi *EBI[T]) BulkCreate(
 
 		bII := esutil.BulkIndexerItem{
 			Action: opts.Operation, // e.g.: "index", "update", "delete", etc.
-			Index:  opts.Index,
+			Index:  indexName,
 
 			// Document successfully indexed.
 			OnSuccess: func(_ context.Context, _ esutil.BulkIndexerItem, _ esutil.BulkIndexerResponseItem) {
 				// Update metrics.
 				metrics.IncreaseDocsSucceeded()
 
-				// Ensures metrics channel is updated.
-				if opts.MetricsCh != nil {
-					opts.MetricsCh <- metrics
-				}
+				// This callback runs on an esutil worker goroutine — it
+				// must never block on a slow/absent metrics reader.
+				bestEffortMetricsSend(opts.MetricsCh, metrics)
 			},
 
 			// Document failed to index.
@@ -557,10 +669,9 @@ func (ebi *EBI[T]) BulkCreate(
 
 				metrics.IncrementErrorCount()
 
-				// Ensures metrics channel is updated.
-				if opts.MetricsCh != nil {
-					opts.MetricsCh <- metrics
-				}
+				// This callback runs on an esutil worker goroutine — it
+				// must never block on a slow/absent metrics reader.
+				bestEffortMetricsSend(opts.MetricsCh, metrics)
 			},
 		}
 
@@ -590,6 +701,15 @@ func (ebi *EBI[T]) BulkCreate(
 
 		// Actually add the document to the bulk indexer.
 		if err := bi.Add(ctx, bII); err != nil {
+			// A cancellation racing the Add surfaces here as esutil's
+			// wrapped ctx error; report it uniformly as the cancellation
+			// it is, matching the top-of-loop check.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ErrorCatalog.
+					MustGet(ErrContextCancelled).
+					NewFailedToError(customerror.WithError(ctxErr))
+			}
+
 			return ErrorCatalog.
 				MustGet(ErrFailedToAddDocumentToBulkIndexer).
 				NewFailedToError(
@@ -605,6 +725,24 @@ func (ebi *EBI[T]) BulkCreate(
 		if data != nil {
 			metrics.UpdateBytesProcessed(int64(len(data)))
 		}
+
+		// Per-document metrics delivery. Best-effort and inline —
+		// deferring these sends would accumulate one per document and
+		// fire them all (blocking) at return time.
+		bestEffortMetricsSend(opts.MetricsCh, metrics)
+	}
+
+	// Flush the remaining buffered documents BEFORE reading the stats:
+	// with the default FlushBytes and a small doc set the ONLY flush
+	// happens inside Close — reading Stats() first would miss every
+	// failure from that final flush and report success.
+	if err := closeBI(); err != nil {
+		return ErrorCatalog.
+			MustGet(ErrFailedToBulkIndexDocuments).
+			NewFailedToError(
+				customerror.WithError(err),
+				customerror.WithTag("bi.Close"),
+			)
 	}
 
 	// Final statistics.
@@ -622,10 +760,8 @@ func (ebi *EBI[T]) BulkCreate(
 
 	ebi.logger.Debuglnf("Stats: %+v", stats)
 
-	// Ensures metrics channel is updated - one last time.
-	if opts.MetricsCh != nil {
-		opts.MetricsCh <- metrics
-	}
+	// Ensures metrics channel is updated - one last time (best-effort).
+	bestEffortMetricsSend(opts.MetricsCh, metrics)
 
 	return nil
 }
@@ -711,6 +847,15 @@ func New[T any](
 	}
 
 	defer res.Body.Close()
+
+	// A transport-level success can still be an HTTP error (401/403/503):
+	// without this check an unreachable-in-practice cluster yields a
+	// "working" client.
+	if res.IsError() {
+		return nil, ErrorCatalog.
+			MustGet(ErrFailedToPing).
+			NewFailedToError(customerror.WithField("response", res.String()))
+	}
 
 	return &EBI[T]{
 		client: client,

--- a/ebi_audit_test.go
+++ b/ebi_audit_test.go
@@ -171,6 +171,7 @@ func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
 				if cfg.pingStatus != 0 {
 					w.WriteHeader(cfg.pingStatus)
 				}
+
 				return
 			}
 			_, _ = w.Write([]byte(`{
@@ -185,6 +186,7 @@ func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
 			if cfg.nodesStatsStatus != 0 {
 				w.WriteHeader(cfg.nodesStatsStatus)
 				_, _ = w.Write([]byte(cfg.nodesStatsBody))
+
 				return
 			}
 			_, _ = w.Write([]byte(`{
@@ -196,6 +198,7 @@ func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
+
 				return
 			}
 
@@ -203,6 +206,7 @@ func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
 			if actions == nil {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte(`{"error":"malformed NDJSON"}`))
+
 				return
 			}
 
@@ -226,6 +230,7 @@ func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
 							"reason": "forced item failure",
 						},
 					}})
+
 					continue
 				}
 
@@ -245,6 +250,7 @@ func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
 			if cfg.refreshStatus != 0 {
 				w.WriteHeader(cfg.refreshStatus)
 				_, _ = w.Write([]byte(`{"error":{"type":"forced","reason":"forced refresh failure"},"status":500}`))
+
 				return
 			}
 			_, _ = w.Write([]byte(`{"_shards":{"total":1,"successful":1,"failed":0}}`))
@@ -280,6 +286,7 @@ func runBulkCreateGuarded(
 		return err
 	case <-time.After(auditTimeout):
 		t.Fatal("deadlock: BulkCreate did not return within the audit timeout")
+
 		return nil
 	}
 }
@@ -931,6 +938,7 @@ func TestBulkCreate_FlushCallbacksWired(t *testing.T) {
 		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
 		WithFlushStartFunc[*TestModel](func(ctx context.Context) context.Context {
 			starts.Add(1)
+
 			return ctx
 		}),
 		WithFlushEndFunc[*TestModel](func(context.Context) {

--- a/ebi_audit_test.go
+++ b/ebi_audit_test.go
@@ -1,0 +1,1062 @@
+package ebi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/elastic/go-elasticsearch/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file is the regression suite for the 2026-07 audit findings (B1-B14):
+// channel deadlocks, metrics snapshot races, opts mutation/reuse hazards,
+// stats-read-before-final-flush, dead RefreshPolicy/FlushStartFunc/
+// FlushEndFunc/DocAsUpsert options, and unchecked HTTP error responses.
+//
+// Everything runs against captureES, a fake Elasticsearch server that
+// CAPTURES requests (paths, query params, parsed NDJSON bulk bodies) and
+// returns configurable bulk responses — extending the minimal fakeESServer
+// from ebi_leak_test.go.
+
+// auditTimeout bounds every BulkCreate call in this file: the pre-fix bugs
+// under test are deadlocks, so an unguarded call would hang the whole suite
+// instead of failing.
+const auditTimeout = 10 * time.Second
+
+//////
+// Fake ES server with request capture.
+//////
+
+// bulkAction is one parsed action from an NDJSON /_bulk request body,
+// paired with its source document (nil for delete operations).
+type bulkAction struct {
+	Op     string          // "index", "create", "update" or "delete".
+	Index  string          // _index from the action metadata line.
+	DocID  string          // _id from the action metadata line.
+	Source json.RawMessage // The line following the action; nil for delete.
+}
+
+// capturedBulk is one captured request to the /_bulk endpoint.
+type capturedBulk struct {
+	Path    string
+	Query   url.Values
+	Actions []bulkAction
+}
+
+// captureESConfig configures captureES behavior. Set at construction only —
+// the handler runs on server goroutines, so mutating after first use would
+// race.
+type captureESConfig struct {
+	// pingStatus, when non-zero, forces this HTTP status on HEAD / (the
+	// Ping request issued by New).
+	pingStatus int
+
+	// nodesStatsStatus/nodesStatsBody, when status is non-zero, force
+	// every /_nodes/stats response.
+	nodesStatsStatus int
+	nodesStatsBody   string
+
+	// refreshStatus, when non-zero, forces this status on /_refresh.
+	refreshStatus int
+
+	// failBulkItems makes /_bulk respond per-item status 400 errors with
+	// "errors":true — every document fails.
+	failBulkItems bool
+}
+
+// captureES is the richer fake ES server used by the audit regression
+// suite.
+type captureES struct {
+	srv *httptest.Server
+	cfg captureESConfig
+
+	mu   chan struct{} // 1-token semaphore; keeps the struct testify-free.
+	bulk []capturedBulk
+}
+
+func (f *captureES) lock()   { f.mu <- struct{}{} }
+func (f *captureES) unlock() { <-f.mu }
+
+// bulkRequests returns a snapshot of the captured /_bulk requests.
+func (f *captureES) bulkRequests() []capturedBulk {
+	f.lock()
+	defer f.unlock()
+
+	out := make([]capturedBulk, len(f.bulk))
+	copy(out, f.bulk)
+
+	return out
+}
+
+// allActions flattens the actions of every captured /_bulk request.
+func (f *captureES) allActions() []bulkAction {
+	var acc []bulkAction
+	for _, b := range f.bulkRequests() {
+		acc = append(acc, b.Actions...)
+	}
+
+	return acc
+}
+
+// parseBulkNDJSON parses an NDJSON bulk body into actions. Returns nil on
+// malformed input (the caller responds 400).
+func parseBulkNDJSON(body []byte) []bulkAction {
+	var actions []bulkAction
+
+	lines := bytes.Split(body, []byte("\n"))
+	for i := 0; i < len(lines); i++ {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+
+		var meta map[string]struct {
+			Index string `json:"_index"`
+			ID    string `json:"_id"`
+		}
+		if err := json.Unmarshal(line, &meta); err != nil || len(meta) != 1 {
+			return nil
+		}
+
+		var act bulkAction
+		for op, m := range meta {
+			act = bulkAction{Op: op, Index: m.Index, DocID: m.ID}
+		}
+
+		// Every operation except delete is followed by a source line.
+		if act.Op != "delete" {
+			i++
+			for i < len(lines) && len(bytes.TrimSpace(lines[i])) == 0 {
+				i++
+			}
+			if i >= len(lines) {
+				return nil
+			}
+			act.Source = json.RawMessage(bytes.TrimSpace(lines[i]))
+		}
+
+		actions = append(actions, act)
+	}
+
+	return actions
+}
+
+// newCaptureES starts the capture server. Response shape matches what the
+// v8 client + esutil expect (X-Elastic-Product header, per-item bulk
+// responses positionally aligned with the request actions).
+func newCaptureES(t *testing.T, cfg captureESConfig) *captureES {
+	t.Helper()
+
+	f := &captureES{cfg: cfg, mu: make(chan struct{}, 1)}
+
+	f.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Elastic-Product", "Elasticsearch")
+
+		path := r.URL.Path
+		switch {
+		case path == "/" || path == "":
+			if r.Method == http.MethodHead {
+				if cfg.pingStatus != 0 {
+					w.WriteHeader(cfg.pingStatus)
+				}
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"name":"node1","cluster_name":"test-cluster","cluster_uuid":"test-uuid",
+				"version":{"number":"8.11.0","build_flavor":"default","build_type":"docker",
+					"build_hash":"abc","build_date":"2024-01-01","build_snapshot":false,
+					"lucene_version":"9.0.0","minimum_wire_compatibility_version":"7.17.0",
+					"minimum_index_compatibility_version":"7.0.0"},
+				"tagline":"You Know, for Search"
+			}`))
+		case strings.Contains(path, "_nodes/stats"):
+			if cfg.nodesStatsStatus != 0 {
+				w.WriteHeader(cfg.nodesStatsStatus)
+				_, _ = w.Write([]byte(cfg.nodesStatsBody))
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"_nodes":{"total":1,"successful":1,"failed":0},
+				"cluster_name":"test-cluster",
+				"nodes":{}
+			}`))
+		case strings.Contains(path, "_bulk"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			actions := parseBulkNDJSON(body)
+			if actions == nil {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":"malformed NDJSON"}`))
+				return
+			}
+
+			f.lock()
+			f.bulk = append(f.bulk, capturedBulk{
+				Path:    path,
+				Query:   r.URL.Query(),
+				Actions: actions,
+			})
+			f.unlock()
+
+			// One response item per action, positionally aligned —
+			// esutil indexes response items against its in-flight items.
+			items := make([]map[string]any, 0, len(actions))
+			for _, a := range actions {
+				if cfg.failBulkItems {
+					items = append(items, map[string]any{a.Op: map[string]any{
+						"_index": a.Index, "_id": a.DocID, "status": 400,
+						"error": map[string]any{
+							"type":   "mapper_parsing_exception",
+							"reason": "forced item failure",
+						},
+					}})
+					continue
+				}
+
+				items = append(items, map[string]any{a.Op: map[string]any{
+					"_index": a.Index, "_id": a.DocID, "status": 200,
+					"result": map[string]string{
+						"index": "created", "create": "created",
+						"update": "updated", "delete": "deleted",
+					}[a.Op],
+				}})
+			}
+
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"took": 1, "errors": cfg.failBulkItems, "items": items,
+			})
+		case strings.HasSuffix(path, "/_refresh"):
+			if cfg.refreshStatus != 0 {
+				w.WriteHeader(cfg.refreshStatus)
+				_, _ = w.Write([]byte(`{"error":{"type":"forced","reason":"forced refresh failure"},"status":500}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"_shards":{"total":1,"successful":1,"failed":0}}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+
+	t.Cleanup(f.srv.Close)
+
+	return f
+}
+
+// runBulkCreateGuarded runs BulkCreate under the audit timeout so a
+// regressed deadlock fails the test instead of hanging the suite.
+func runBulkCreateGuarded(
+	t *testing.T,
+	ctx context.Context,
+	e *EBI[*TestModel],
+	docs []*TestModel,
+	opts *BulkOptions[*TestModel],
+) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- e.BulkCreate(ctx, docs, opts)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(auditTimeout):
+		t.Fatal("deadlock: BulkCreate did not return within the audit timeout")
+		return nil
+	}
+}
+
+//////
+// Unit: option wiring (B9).
+//////
+
+// TestNewBulkOptions_DocAsUpsert pins B9: WithDocAsUpsert(false) used to be
+// impossible — the value was dropped by NewBulkOptions and then flipped
+// back to true by the `default:"true"` tag inside process().
+func TestNewBulkOptions_DocAsUpsert(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default is true", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := NewBulkOptions[*TestModel]("idx", rawMessage)
+		require.NoError(t, err)
+		assert.True(t, opts.DocAsUpsert, "DocAsUpsert must default to true via NewBulkOptions")
+	})
+
+	t.Run("explicit false sticks", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := NewBulkOptions(
+			"idx",
+			rawMessage,
+			WithDocAsUpsert[*TestModel](false),
+		)
+		require.NoError(t, err)
+		assert.False(t, opts.DocAsUpsert,
+			"WithDocAsUpsert(false) must not be flipped back to true (B9): update-only bulk ops would silently upsert")
+	})
+
+	t.Run("explicit true sticks", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := NewBulkOptions(
+			"idx",
+			rawMessage,
+			WithDocAsUpsert[*TestModel](true),
+		)
+		require.NoError(t, err)
+		assert.True(t, opts.DocAsUpsert)
+	})
+}
+
+//////
+// Unit: BulkCreate input validation (B8).
+//////
+
+// TestBulkCreate_EmptySampleDoc_StructLiteral pins B8: a caller-constructed
+// &BulkOptions{} with an empty-but-non-nil SampleDoc passes the
+// `validate:"required"` tag and used to reach `targetBatchSizeBytes /
+// docSize` with docSize == 0 — an integer divide-by-zero panic.
+func TestBulkCreate_EmptySampleDoc_StructLiteral(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	for _, tc := range []struct {
+		name      string
+		sampleDoc json.RawMessage
+	}{
+		{"empty non-nil RawMessage", json.RawMessage{}},
+		{"nil RawMessage", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+
+			require.NotPanics(t, func() {
+				err = e.BulkCreate(
+					context.Background(),
+					testModelGenerator(2),
+					&BulkOptions[*TestModel]{
+						Index:     "audit-b8",
+						SampleDoc: tc.sampleDoc,
+					},
+				)
+			}, "BulkCreate must not panic on an empty SampleDoc (B8)")
+
+			require.Error(t, err, "empty SampleDoc must surface as an error, not a divide-by-zero panic")
+		})
+	}
+}
+
+//////
+// Unit: HTTP error responses surfaced (B13).
+//////
+
+// TestBulkCreate_NodeStats500_ErrorSurfaces pins B13: a 401/403/500 from
+// /_nodes/stats used to decode into a zero NodesStats and silently produce
+// bogus pressure numbers and worker counts.
+func TestBulkCreate_NodeStats500_ErrorSurfaces(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{
+		nodesStatsStatus: http.StatusInternalServerError,
+		nodesStatsBody:   `{"error":{"type":"security_exception","reason":"forced"},"status":500}`,
+	})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"audit-b13",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(2), opts)
+	require.Error(t, err,
+		"a 500 from /_nodes/stats must surface as an error, not decode into zero stats (B13)")
+}
+
+// TestNew_PingErrorStatus_ReturnsError pins B13 on the factory: New checked
+// the Ping transport error but not res.IsError(), so a 401/403/503 cluster
+// yielded a "working" client.
+func TestNew_PingErrorStatus_ReturnsError(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{pingStatus: http.StatusForbidden})
+
+	_, err := New[*TestModel](
+		context.Background(),
+		elasticsearch.Config{Addresses: []string{f.srv.URL}},
+	)
+	require.Error(t, err, "New must fail when Ping returns an HTTP error status (B13)")
+}
+
+//////
+// E2E: metrics channel behavior (B1/B2/B3/B4).
+//////
+
+// TestBulkCreate_MetricsSnapshots_AreCopies pins B3/B4: every MetricsCh
+// send used to push the LIVE *Metrics pointer, so receivers reading (or
+// json.Marshal-ing) fields raced with writers mutating under the mutex —
+// and every receive aliased the same struct.
+//
+// The reader here marshals each snapshot WHILE indexing runs; under -race
+// the pre-fix code trips. Post-fix, every received snapshot must be a
+// distinct copy.
+func TestBulkCreate_MetricsSnapshots_AreCopies(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	metricsCh := make(chan *Metrics, 4096)
+	errorCh := make(chan error, 4096)
+
+	// The reader is stopped via a signal channel, NOT by closing
+	// metricsCh: the metrics goroutine winds down asynchronously after
+	// BulkCreate returns, and closing a channel a producer may still be
+	// sending on is a caller-contract violation.
+	stopReader := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	var received []*Metrics
+
+	go func() {
+		defer close(readerDone)
+
+		for {
+			select {
+			case m := <-metricsCh:
+				// Reading fields concurrently with the indexing writers
+				// is exactly what production metrics consumers do.
+				if _, err := json.Marshal(m); err != nil {
+					t.Errorf("snapshot marshal failed: %v", err)
+				}
+
+				received = append(received, m)
+			case <-stopReader:
+				return
+			}
+		}
+	}()
+
+	opts, err := NewBulkOptions(
+		"audit-snapshots",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithMetricsCh[*TestModel](metricsCh),
+		WithErrorCh[*TestModel](errorCh),
+		WithMetricsCheck[*TestModel](5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(500), opts)
+	require.NoError(t, err)
+
+	// Give the metrics goroutine's wind-down a moment to deliver
+	// stragglers, then stop the reader.
+	time.Sleep(100 * time.Millisecond)
+	close(stopReader)
+	<-readerDone
+
+	for drained := false; !drained; {
+		select {
+		case err := <-errorCh:
+			t.Errorf("unexpected async error: %v", err)
+		default:
+			drained = true
+		}
+	}
+
+	require.NotEmpty(t, received, "at least one metrics snapshot must be delivered")
+
+	// Snapshots must be independent copies: mutating one received snapshot
+	// must not affect any other. Aliased pointers (the pre-fix behavior —
+	// every send pushed the same live *Metrics) fail this check.
+	seen := make(map[*Metrics]bool, len(received))
+	for i, m := range received {
+		if seen[m] {
+			t.Fatalf("snapshot %d aliases a previously received snapshot: MetricsCh must carry copies (B4)", i)
+		}
+		seen[m] = true
+	}
+
+	// The final snapshot must reflect actual progress.
+	last := received[len(received)-1]
+	assert.Positive(t, last.DocsProcessed, "final snapshot must reflect processed docs")
+}
+
+// TestBulkCreate_UnbufferedMetricsChNoReader_Completes pins B1/B2/B3: with
+// an unbuffered MetricsCh and NO reader, BulkCreate used to park forever in
+// its epilogue on the per-document deferred sends (one blocking send per
+// doc, all deferred to return time).
+func TestBulkCreate_UnbufferedMetricsChNoReader_Completes(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	metricsCh := make(chan *Metrics) // Unbuffered, nobody reads it. Ever.
+
+	opts, err := NewBulkOptions(
+		"audit-deadlock",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithMetricsCh[*TestModel](metricsCh),
+		WithMetricsCheck[*TestModel](5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(50), opts)
+	require.NoError(t, err,
+		"BulkCreate must complete even when nobody reads MetricsCh: metrics are best-effort telemetry (B1/B2/B3)")
+}
+
+// TestBulkCreate_MetricsGoroutineNoLeak_DeadReaders pins B2/B12: with a
+// MetricsCh nobody drains and an unbuffered ErrorCh whose reader is gone,
+// the metrics goroutine used to park forever — either in its accumulated
+// deferred MetricsCh sends (B2) or in asyncErrorSend guarded by the CALLER
+// ctx (Background here, never fires) instead of the goroutine ctx (B12).
+//
+// The failing /_refresh + always-true RefreshFunc force an error send from
+// INSIDE the metrics goroutine on every tick, exercising the B12 path.
+// Extends the leak tests in ebi_leak_test.go, which only cover nil
+// MetricsCh/ErrorCh.
+func TestBulkCreate_MetricsGoroutineNoLeak_DeadReaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping goroutine-count test in -short mode")
+	}
+
+	f := newCaptureES(t, captureESConfig{refreshStatus: http.StatusInternalServerError})
+	e := newTestEBI(t, f.srv)
+
+	docs := testModelGenerator(20_000)
+
+	runOnce := func() error {
+		metricsCh := make(chan *Metrics, 1) // Fills once, then nobody reads.
+		errorCh := make(chan error)         // Unbuffered, reader already gone.
+
+		opts, err := NewBulkOptions(
+			"audit-leak",
+			rawMessage,
+			WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+			WithMetricsCh[*TestModel](metricsCh),
+			WithErrorCh[*TestModel](errorCh),
+			WithMetricsCheck[*TestModel](time.Millisecond),
+			WithRefreshFunc[*TestModel](func(context.Context, *Metrics) bool { return true }),
+		)
+		if err != nil {
+			return err
+		}
+
+		return runBulkCreateGuarded(t, context.Background(), e, docs, opts)
+	}
+
+	// Warm up lazy package state before sampling the baseline.
+	require.NoError(t, runOnce())
+
+	settleAndGC := func() {
+		runtime.GC()
+		runtime.Gosched()
+		time.Sleep(300 * time.Millisecond)
+		runtime.GC()
+	}
+	settleAndGC()
+	baseline := runtime.NumGoroutine()
+
+	const runs = 6
+	for i := 0; i < runs; i++ {
+		require.NoError(t, runOnce())
+	}
+
+	settleAndGC()
+	after := runtime.NumGoroutine()
+
+	// Same slack rationale as TestBulkCreate_NoMetricsGoroutineLeak_
+	// AfterReturn: a real leak shows ~+1 per run, well past +5.
+	if after > baseline+5 {
+		t.Errorf("metrics goroutine leaked with dead channel readers: baseline=%d after=%d (runs=%d)",
+			baseline, after, runs)
+	}
+}
+
+// TestBulkCreate_CtxCancel_DeadReaders_ReturnsPromptly pins B1/B12 on the
+// cancellation path: cancel mid-run with unbuffered channels and dead
+// readers must return ErrContextCancelled promptly — the pre-fix code hung
+// in the accumulated deferred MetricsCh sends on the return path.
+func TestBulkCreate_CtxCancel_DeadReaders_ReturnsPromptly(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	metricsCh := make(chan *Metrics) // Unbuffered, no reader.
+	errorCh := make(chan error)      // Unbuffered, no reader.
+
+	// PauseFunc keeps the run alive deterministically: the first metrics
+	// tick flips the status to paused, after which every loop iteration
+	// sleeps PauseDuration — plenty of runway to cancel mid-run.
+	opts, err := NewBulkOptions(
+		"audit-cancel",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithMetricsCh[*TestModel](metricsCh),
+		WithErrorCh[*TestModel](errorCh),
+		WithMetricsCheck[*TestModel](time.Millisecond),
+		WithPauseFunc[*TestModel](func(*Metrics) bool { return true }),
+		WithPauseDuration[*TestModel](5*time.Millisecond),
+	)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+
+	go func() {
+		done <- e.BulkCreate(ctx, testModelGenerator(20_000), opts)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "context cancelled",
+			"cancellation mid-run must surface as ErrContextCancelled")
+	case <-time.After(auditTimeout):
+		t.Fatal("deadlock: BulkCreate did not return after ctx cancel with dead channel readers (B1/B12)")
+	}
+}
+
+//////
+// E2E: stats read before final flush (B6).
+//////
+
+// TestBulkCreate_FailuresInFinalFlush_ReturnError pins B6: with the default
+// FlushBytes (~5MB) and a small doc set, the ONLY flush happens inside
+// Close — which used to run AFTER Stats() was read, so per-item failures
+// never reached the NumFailed check and BulkCreate returned nil.
+func TestBulkCreate_FailuresInFinalFlush_ReturnError(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{failBulkItems: true})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"audit-b6",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(10), opts)
+	require.Error(t, err,
+		"BulkCreate must report documents that failed during the final flush (B6)")
+
+	// The failures must have actually reached ES (i.e. the flush happened
+	// before the check, not skipped entirely).
+	require.NotEmpty(t, f.bulkRequests(), "the final flush must have hit /_bulk")
+}
+
+//////
+// E2E: opts wiring and immutability (B10/B10a/B11).
+//////
+
+// TestBulkCreate_FlushBytesRespected pins B10a: a caller-set FlushBytes was
+// unconditionally overwritten with ~5MB, collapsing everything into a
+// single bulk request.
+func TestBulkCreate_FlushBytesRespected(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"audit-flushbytes",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithFlushBytes[*TestModel](256),
+		WithNumWorkers[*TestModel](NumWorkersManual(1)),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(100), opts)
+	require.NoError(t, err)
+
+	// 100 docs at ~100 bytes each (meta+source) against FlushBytes=256
+	// must produce many bulk requests; the pre-fix ~5MB override produced
+	// exactly one.
+	got := len(f.bulkRequests())
+	assert.Greater(t, got, 1,
+		"WithFlushBytes(256) must split 100 docs across multiple bulk requests (B10a); got %d request(s)", got)
+}
+
+// TestBulkCreate_BatchSizeDrivesFlush pins B10b: WithBatchSize was computed
+// and then wired to NOTHING (HyperparameterOptimization was "optimizing" a
+// dead parameter). With FlushBytes unset, a caller-set BatchSize must drive
+// the flush cadence.
+func TestBulkCreate_BatchSizeDrivesFlush(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"audit-batchsize",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithBatchSize[*TestModel](3),
+		WithNumWorkers[*TestModel](NumWorkersManual(1)),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(30), opts)
+	require.NoError(t, err)
+
+	// BatchSize=3 with a ~24-byte sample doc means a tiny flush threshold:
+	// 30 docs must span multiple bulk requests. The pre-fix dead parameter
+	// left the ~5MB default, collapsing everything into a single request.
+	got := len(f.bulkRequests())
+	assert.Greater(t, got, 1,
+		"WithBatchSize must drive the flush cadence when FlushBytes is unset (B10b); got %d request(s)", got)
+}
+
+// TestDiscoverWorkerNodes_NilNodeEntry pins the nil-entry guard on the
+// discovery path: a `"nodes": {"x": null}` payload decodes into a nil
+// *NodeDetails, which must be skipped, not dereferenced.
+func TestDiscoverWorkerNodes_NilNodeEntry(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{
+		nodesStatsStatus: http.StatusOK,
+		nodesStatsBody: `{
+			"_nodes":{"total":2,"successful":2,"failed":0},
+			"cluster_name":"test-cluster",
+			"nodes":{"a":null,"b":{"roles":["data","ingest"]}}
+		}`,
+	})
+	e := newTestEBI(t, f.srv)
+
+	n, err := e.discoverWorkerNodes(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n, "only the non-nil data node must be counted")
+}
+
+// TestBulkCreate_OptsNotMutated_IndexNameFuncNotCompounded pins B10:
+// BulkCreate used to write the IndexNameFunc result back into opts.Index,
+// so reusing opts re-suffixed the index name on every call
+// ("base-suffix-suffix"). HyperparameterOptimization reuses opts across
+// every iteration, so this corrupted every run after the first.
+func TestBulkCreate_OptsNotMutated_IndexNameFuncNotCompounded(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"base",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithIndexNameFunc[*TestModel](func(indexName string) string {
+			return indexName + "-suffix"
+		}),
+		WithNumWorkers[*TestModel](NumWorkersManual(1)),
+	)
+	require.NoError(t, err)
+
+	for run := 0; run < 2; run++ {
+		err := runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(5), opts)
+		require.NoError(t, err, "run %d", run)
+	}
+
+	assert.Equal(t, "base", opts.Index,
+		"BulkCreate must not write the derived index name back into opts (B10)")
+
+	actions := f.allActions()
+	require.NotEmpty(t, actions)
+
+	for i, a := range actions {
+		assert.Equal(t, "base-suffix", a.Index,
+			"action %d: index name must be derived fresh per call, never compounded (B10)", i)
+	}
+}
+
+// TestBulkCreate_ConcurrentCallsSharingOpts pins the B10 data race: two
+// concurrent BulkCreate calls sharing one opts used to race on the plain
+// writes to opts.BatchSize/NumWorkers/FlushBytes/Index (caught by -race).
+// The struct-literal variant additionally pins the process() defaults
+// application, which must happen on a private copy, not the shared struct.
+func TestBulkCreate_ConcurrentCallsSharingOpts(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, opts *BulkOptions[*TestModel]) {
+		t.Helper()
+
+		f := newCaptureES(t, captureESConfig{})
+		e := newTestEBI(t, f.srv)
+
+		const callers = 2
+
+		done := make(chan error, callers)
+
+		for i := 0; i < callers; i++ {
+			go func() {
+				done <- e.BulkCreate(context.Background(), testModelGenerator(500), opts)
+			}()
+		}
+
+		for i := 0; i < callers; i++ {
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(auditTimeout):
+				t.Fatal("concurrent BulkCreate calls sharing opts did not finish in time")
+			}
+		}
+	}
+
+	t.Run("opts from NewBulkOptions", func(t *testing.T) {
+		t.Parallel()
+
+		opts, err := NewBulkOptions(
+			"audit-concurrent",
+			rawMessage,
+			WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		)
+		require.NoError(t, err)
+
+		run(t, opts)
+	})
+
+	t.Run("struct-literal opts", func(t *testing.T) {
+		t.Parallel()
+
+		// Zero-valued default-tagged fields (MetricsCheck, FlushInterval,
+		// Operation, ...) force process() to apply defaults on BOTH calls.
+		opts := &BulkOptions[*TestModel]{
+			Index:     "audit-concurrent-literal",
+			SampleDoc: rawMessage,
+		}
+
+		run(t, opts)
+
+		// The caller's struct must come out untouched: defaults are
+		// applied to a private copy.
+		assert.Zero(t, opts.MetricsCheck, "process() defaults must not be written into the caller's opts")
+		assert.Zero(t, opts.Operation, "process() defaults must not be written into the caller's opts")
+	})
+}
+
+// TestBulkCreate_RefreshPolicyWired pins B11: RefreshPolicy was accepted
+// and validated but never passed to esutil, so ES never saw a refresh
+// parameter.
+func TestBulkCreate_RefreshPolicyWired(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		policy RefreshPolicy
+		want   string
+	}{
+		// ES bulk accepts "true"/"false"/"wait_for": the exported
+		// "immediate" constant must be mapped to "true".
+		{"wait_for passes through", RefreshPolicyWaitFor, "wait_for"},
+		{"immediate maps to true", RefreshPolicyImmediate, "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newCaptureES(t, captureESConfig{})
+			e := newTestEBI(t, f.srv)
+
+			opts, err := NewBulkOptions(
+				"audit-refresh",
+				rawMessage,
+				WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+				WithRefreshPolicy[*TestModel](tc.policy),
+				WithNumWorkers[*TestModel](NumWorkersManual(1)),
+			)
+			require.NoError(t, err)
+
+			err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(5), opts)
+			require.NoError(t, err)
+
+			reqs := f.bulkRequests()
+			require.NotEmpty(t, reqs)
+
+			for i, r := range reqs {
+				assert.Equal(t, tc.want, r.Query.Get("refresh"),
+					"bulk request %d must carry the refresh policy (B11)", i)
+			}
+		})
+	}
+}
+
+// TestBulkCreate_FlushCallbacksWired pins B11: FlushStartFunc/FlushEndFunc
+// existed on BulkOptions with esutil-compatible signatures but were never
+// passed to the bulk indexer.
+func TestBulkCreate_FlushCallbacksWired(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	var starts, ends atomic.Int64
+
+	opts, err := NewBulkOptions(
+		"audit-flush-callbacks",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithFlushStartFunc[*TestModel](func(ctx context.Context) context.Context {
+			starts.Add(1)
+			return ctx
+		}),
+		WithFlushEndFunc[*TestModel](func(context.Context) {
+			ends.Add(1)
+		}),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(10), opts)
+	require.NoError(t, err)
+
+	assert.Positive(t, starts.Load(), "FlushStartFunc must be invoked at least once (B11)")
+	assert.Positive(t, ends.Load(), "FlushEndFunc must be invoked at least once (B11)")
+}
+
+//////
+// E2E: update/delete operations (B9 end-to-end + happy/bad paths).
+//////
+
+// TestBulkCreate_UpdateOperation_DocAsUpsertBody pins B9 end-to-end: the
+// bulk NDJSON body for update operations must include "doc_as_upsert":true
+// by default and OMIT it entirely with WithDocAsUpsert(false).
+func TestBulkCreate_UpdateOperation_DocAsUpsertBody(t *testing.T) {
+	t.Parallel()
+
+	run := func(t *testing.T, wantUpsert bool, extra ...BulkOptionsFunc[*TestModel]) []bulkAction {
+		t.Helper()
+
+		f := newCaptureES(t, captureESConfig{})
+		e := newTestEBI(t, f.srv)
+
+		options := append([]BulkOptionsFunc[*TestModel]{
+			WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+			WithOperation[*TestModel]("update"),
+			WithNumWorkers[*TestModel](NumWorkersManual(1)),
+		}, extra...)
+
+		opts, err := NewBulkOptions("audit-update", rawMessage, options...)
+		require.NoError(t, err)
+		require.Equal(t, wantUpsert, opts.DocAsUpsert)
+
+		err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(3), opts)
+		require.NoError(t, err)
+
+		actions := f.allActions()
+		require.NotEmpty(t, actions)
+
+		return actions
+	}
+
+	t.Run("default true includes doc_as_upsert", func(t *testing.T) {
+		t.Parallel()
+
+		for i, a := range run(t, true) {
+			require.Equal(t, "update", a.Op)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(a.Source, &body))
+
+			assert.Contains(t, body, "doc", "action %d must wrap the document in a doc field", i)
+			assert.Contains(t, body, "doc_as_upsert", "action %d must carry doc_as_upsert by default", i)
+			assert.Equal(t, "true", string(body["doc_as_upsert"]), "action %d", i)
+		}
+	})
+
+	t.Run("explicit false omits doc_as_upsert", func(t *testing.T) {
+		t.Parallel()
+
+		for i, a := range run(t, false, WithDocAsUpsert[*TestModel](false)) {
+			require.Equal(t, "update", a.Op)
+
+			var body map[string]json.RawMessage
+			require.NoError(t, json.Unmarshal(a.Source, &body))
+
+			assert.Contains(t, body, "doc", "action %d must wrap the document in a doc field", i)
+			assert.NotContains(t, body, "doc_as_upsert",
+				"action %d: WithDocAsUpsert(false) must omit doc_as_upsert entirely (B9) — updates on missing docs must error, not upsert", i)
+		}
+	})
+}
+
+// TestBulkCreate_DeleteOperation_NoBody covers the delete happy path: the
+// bulk body carries only metadata lines, no sources.
+func TestBulkCreate_DeleteOperation_NoBody(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"audit-delete",
+		rawMessage,
+		WithDocumentIDFunc(func(d *TestModel) string { return d.ID }),
+		WithOperation[*TestModel]("delete"),
+		WithNumWorkers[*TestModel](NumWorkersManual(1)),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(5), opts)
+	require.NoError(t, err)
+
+	actions := f.allActions()
+	require.Len(t, actions, 5)
+
+	for i, a := range actions {
+		assert.Equal(t, "delete", a.Op, "action %d", i)
+		assert.Nil(t, a.Source, "action %d: delete operations must not carry a body", i)
+	}
+}
+
+// TestBulkCreate_InvalidOperation covers the bad path: an unknown Operation
+// must fail fast with ErrInvalidOperation.
+func TestBulkCreate_InvalidOperation(t *testing.T) {
+	t.Parallel()
+
+	f := newCaptureES(t, captureESConfig{})
+	e := newTestEBI(t, f.srv)
+
+	opts, err := NewBulkOptions(
+		"audit-bad-op",
+		rawMessage,
+		WithOperation[*TestModel]("bogus"),
+	)
+	require.NoError(t, err)
+
+	err = runBulkCreateGuarded(t, context.Background(), e, testModelGenerator(2), opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "operation")
+}

--- a/ebi_leak_test.go
+++ b/ebi_leak_test.go
@@ -105,6 +105,7 @@ func fakeESServer(t *testing.T) *httptest.Server {
 	}))
 
 	t.Cleanup(srv.Close)
+
 	return srv
 }
 
@@ -122,6 +123,7 @@ func newTestEBI(t *testing.T, srv *httptest.Server) *EBI[*TestModel] {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, ebi)
+
 	return ebi
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -143,6 +143,34 @@ func (gm *Metrics) IncrementErrorCount() {
 	gm.ErrorCount++
 }
 
+// UpdateNodeStats replaces the node stats.
+func (gm *Metrics) UpdateNodeStats(ns *NodesStats) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	gm.NodeStats = ns
+}
+
+// updateNodeInfo updates the node topology snapshot. It runs on the metrics
+// goroutine while GetMetrics readers run on other goroutines, so these
+// fields must never be written without the lock.
+func (gm *Metrics) updateNodeInfo(numDataNodes, ramPerNodeGB int) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	gm.numDataNodes = numDataNodes
+	gm.ramPerNodeGB = ramPerNodeGB
+}
+
+// getNodeInfo returns the node topology snapshot (numDataNodes,
+// ramPerNodeGB). Locked counterpart of updateNodeInfo.
+func (gm *Metrics) getNodeInfo() (int, int) {
+	gm.mu.Lock()
+	defer gm.mu.Unlock()
+
+	return gm.numDataNodes, gm.ramPerNodeGB
+}
+
 // GetMetrics returns a copy of the Metrics struct.
 func (gm *Metrics) GetMetrics() *Metrics {
 	gm.mu.Lock()

--- a/utils.go
+++ b/utils.go
@@ -56,7 +56,20 @@ func calculateSystemPressure(
 	// - JVM heap usage
 	// - Circuit breaker status
 	// - Indexing pressure memory
+	//
+	// NOTE: Elasticsearch omits whole stats sections depending on node
+	// role, version and the requested metric filter, so every pointer here
+	// can legitimately be nil and every limit can legitimately be 0. Each
+	// factor is guarded individually: a partially-populated node
+	// contributes only the factors it has (the totalFactors accumulators
+	// normalize accordingly), and zero limits are skipped because dividing
+	// by them poisons every pressure number with +Inf/NaN.
 	for _, node := range nodeStats.Nodes {
+		// A null node entry decodes into a nil pointer.
+		if node == nil {
+			continue
+		}
+
 		//////
 		// Data nodes and total RAM.
 		//////
@@ -64,7 +77,11 @@ func calculateSystemPressure(
 		if strings.Contains(strings.Join(node.Roles, ","), "data") {
 			dataNodes++
 
-			totalRAMGB += node.JVM.Mem.HeapMaxInBytes / 1024 / 1024 / 1024
+			// RAM is derived from the JVM heap; a node reporting no JVM
+			// section still counts as a data node, it just contributes 0.
+			if node.JVM != nil && node.JVM.Mem != nil {
+				totalRAMGB += node.JVM.Mem.HeapMaxInBytes / 1024 / 1024 / 1024
+			}
 		}
 
 		if node.JVM != nil && node.JVM.Mem != nil {
@@ -73,7 +90,8 @@ func calculateSystemPressure(
 			totalMemoryFactors += 40
 		}
 
-		if node.Breakers != nil && node.Breakers.Parent != nil {
+		if node.Breakers != nil && node.Breakers.Parent != nil &&
+			node.Breakers.Parent.LimitSizeInBytes > 0 {
 			// Circuit breaker contributes 30% of the memory pressure.
 			breakerPressure := float64(node.Breakers.Parent.EstimatedSizeInBytes) /
 				float64(node.Breakers.Parent.LimitSizeInBytes) * 100
@@ -82,8 +100,9 @@ func calculateSystemPressure(
 		}
 
 		// Indexing pressure memory contributes 30% of the memory pressure.
-		if pressure := node.IndexingPressure.Memory; pressure != nil {
-			if pressure.LimitInBytes > 0 {
+		if node.IndexingPressure != nil && node.IndexingPressure.Memory != nil {
+			if pressure := node.IndexingPressure.Memory; pressure.Current != nil &&
+				pressure.LimitInBytes > 0 {
 				currentPressure := float64(pressure.Current.AllInBytes) /
 					float64(pressure.LimitInBytes) * 100
 				memoryPressurePoints += currentPressure * 0.3
@@ -97,17 +116,20 @@ func calculateSystemPressure(
 		// - Merge pressure
 		if node.Indices != nil {
 			// Write load contributes 50% of the write pressure.
-			if writeLoad := node.Indices.Indexing.WriteLoad; writeLoad > 0 {
+			if node.Indices.Indexing != nil && node.Indices.Indexing.WriteLoad > 0 {
 				// Normalize the write load (assume that >1 is 100% pressure).
-				writePressure := math.Min(writeLoad*100, 100)
+				writePressure := math.Min(node.Indices.Indexing.WriteLoad*100, 100)
 
 				writePressurePoints += writePressure * 0.5
 
 				totalWriteFactors += 50
 			}
 
-			// Merge status contributes 30% of the write pressure.
-			if merges := node.Indices.Merges; merges != nil && merges.TotalTimeInMillis > 0 {
+			// Merge status contributes 30% of the write pressure. It needs
+			// the JVM uptime as the denominator, so the factor is skipped
+			// when the JVM section is missing or uptime is 0.
+			if merges := node.Indices.Merges; merges != nil && merges.TotalTimeInMillis > 0 &&
+				node.JVM != nil && node.JVM.UptimeInMillis > 0 {
 				// If spending more than 10% of the time in merges, consider pressure.
 				mergePressure := math.Min(
 					float64(merges.TotalTimeInMillis)/
@@ -120,7 +142,7 @@ func calculateSystemPressure(
 			}
 
 			// Throttle status contributes 20% of the write pressure.
-			if node.Indices.Indexing.IsThrottled {
+			if node.Indices.Indexing != nil && node.Indices.Indexing.IsThrottled {
 				writePressurePoints += 100 * 0.2
 
 				totalWriteFactors += 20
@@ -149,10 +171,11 @@ func calculateSystemPressure(
 	metrics.UpdateOverallPressure(overallPressure)
 
 	// Calculate average RAM per node.
+	//
+	// NOTE: Written through the locked setter — this runs on the metrics
+	// goroutine while GetMetrics/getNodeInfo readers run elsewhere.
 	if dataNodes > 0 {
-		metrics.numDataNodes = int(dataNodes)
-
-		metrics.ramPerNodeGB = int(totalRAMGB / dataNodes)
+		metrics.updateNodeInfo(int(dataNodes), int(totalRAMGB/dataNodes))
 	}
 }
 
@@ -177,8 +200,9 @@ func updateIndexMetrics[T any](
 	// Calculate, and update system pressure metrics.
 	calculateSystemPressure(metrics, *ns)
 
-	// Nodes stats.
-	metrics.NodeStats = ns
+	// Nodes stats. Written through the locked setter — GetMetrics readers
+	// run on other goroutines.
+	metrics.UpdateNodeStats(ns)
 
 	return nil
 }
@@ -186,20 +210,6 @@ func updateIndexMetrics[T any](
 //////
 // Bulk options process.
 //////
-
-// RoundToNearestThousandDivisibleBy2 rounds up to the nearest thousand and
-// then to the nearest even number divisible by 2.
-func roundToNearestThousandDivisibleBy2(n int) int {
-	// Round up to nearest thousand.
-	thousand := ((n + 999) / 1000) * 1000
-
-	// If not divisible by 2000, round up to next 2000.
-	if thousand%2000 != 0 {
-		thousand = ((thousand + 1999) / 2000) * 2000
-	}
-
-	return thousand
-}
 
 // Process `v`:
 // - Set default values using the `default` field tag.

--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,94 @@ import (
 // Update metrics process.
 //////
 
+// nodeMemoryPressureFactors returns the memory-pressure points contributed
+// by a single node and the factor weight they were computed against: JVM
+// heap usage (40), parent circuit breaker (30), and indexing pressure
+// memory (30).
+//
+// NOTE: Elasticsearch omits whole stats sections depending on node role,
+// version and the requested metric filter, so every pointer here can
+// legitimately be nil and every limit can legitimately be 0. Each factor is
+// guarded individually: a partially-populated node contributes only the
+// factors it has (the caller's totalFactors accumulator normalizes
+// accordingly), and zero limits are skipped because dividing by them
+// poisons every pressure number with +Inf/NaN.
+func nodeMemoryPressureFactors(node *NodeDetails) (float64, float64) {
+	var points, factors float64
+
+	if node.JVM != nil && node.JVM.Mem != nil {
+		// JVM heap contributes 40% of the memory pressure.
+		points += float64(node.JVM.Mem.HeapUsedPercent) * 0.4
+		factors += 40
+	}
+
+	if node.Breakers != nil && node.Breakers.Parent != nil &&
+		node.Breakers.Parent.LimitSizeInBytes > 0 {
+		// Circuit breaker contributes 30% of the memory pressure.
+		breakerPressure := float64(node.Breakers.Parent.EstimatedSizeInBytes) /
+			float64(node.Breakers.Parent.LimitSizeInBytes) * 100
+		points += breakerPressure * 0.3
+		factors += 30
+	}
+
+	// Indexing pressure memory contributes 30% of the memory pressure.
+	if node.IndexingPressure != nil && node.IndexingPressure.Memory != nil {
+		if pressure := node.IndexingPressure.Memory; pressure.Current != nil &&
+			pressure.LimitInBytes > 0 {
+			currentPressure := float64(pressure.Current.AllInBytes) /
+				float64(pressure.LimitInBytes) * 100
+			points += currentPressure * 0.3
+			factors += 30
+		}
+	}
+
+	return points, factors
+}
+
+// nodeWritePressureFactors returns the write-pressure points contributed by
+// a single node and the factor weight they were computed against: write
+// load (50), merge time (30), and throttling (20). Same partial-population
+// contract as nodeMemoryPressureFactors.
+func nodeWritePressureFactors(node *NodeDetails) (float64, float64) {
+	if node.Indices == nil {
+		return 0, 0
+	}
+
+	var points, factors float64
+
+	if node.Indices.Indexing != nil && node.Indices.Indexing.WriteLoad > 0 {
+		// Write load contributes 50% of the write pressure. Normalize the
+		// write load (assume that >1 is 100% pressure).
+		writePressure := math.Min(node.Indices.Indexing.WriteLoad*100, 100)
+
+		points += writePressure * 0.5
+		factors += 50
+	}
+
+	// Merge status contributes 30% of the write pressure. It needs the JVM
+	// uptime as the denominator, so the factor is skipped when the JVM
+	// section is missing or uptime is 0 (div by zero -> +Inf).
+	if merges := node.Indices.Merges; merges != nil && merges.TotalTimeInMillis > 0 &&
+		node.JVM != nil && node.JVM.UptimeInMillis > 0 {
+		// If spending more than 10% of the time in merges, consider pressure.
+		mergePressure := math.Min(
+			float64(merges.TotalTimeInMillis)/
+				float64(node.JVM.UptimeInMillis)*1000, 100,
+		)
+
+		points += mergePressure * 0.3
+		factors += 30
+	}
+
+	// Throttle status contributes 20% of the write pressure.
+	if node.Indices.Indexing != nil && node.Indices.Indexing.IsThrottled {
+		points += 100 * 0.2
+		factors += 20
+	}
+
+	return points, factors
+}
+
 // calculateSystemPressure calculates the system pressure based on the provided
 // node stats. This implementation creates three main metrics:
 //
@@ -52,18 +140,9 @@ func calculateSystemPressure(
 		totalRAMGB int64
 	)
 
-	// Calculated memory pressure based on:
-	// - JVM heap usage
-	// - Circuit breaker status
-	// - Indexing pressure memory
-	//
-	// NOTE: Elasticsearch omits whole stats sections depending on node
-	// role, version and the requested metric filter, so every pointer here
-	// can legitimately be nil and every limit can legitimately be 0. Each
-	// factor is guarded individually: a partially-populated node
-	// contributes only the factors it has (the totalFactors accumulators
-	// normalize accordingly), and zero limits are skipped because dividing
-	// by them poisons every pressure number with +Inf/NaN.
+	// Accumulate each node's memory and write pressure factors (see the
+	// nodeMemoryPressureFactors/nodeWritePressureFactors contracts for how
+	// partially-populated nodes are handled).
 	for _, node := range nodeStats.Nodes {
 		// A null node entry decodes into a nil pointer.
 		if node == nil {
@@ -84,70 +163,13 @@ func calculateSystemPressure(
 			}
 		}
 
-		if node.JVM != nil && node.JVM.Mem != nil {
-			// JVM heap contributes 40% of the memory pressure.
-			memoryPressurePoints += float64(node.JVM.Mem.HeapUsedPercent) * 0.4
-			totalMemoryFactors += 40
-		}
+		memoryPoints, memoryFactors := nodeMemoryPressureFactors(node)
+		memoryPressurePoints += memoryPoints
+		totalMemoryFactors += memoryFactors
 
-		if node.Breakers != nil && node.Breakers.Parent != nil &&
-			node.Breakers.Parent.LimitSizeInBytes > 0 {
-			// Circuit breaker contributes 30% of the memory pressure.
-			breakerPressure := float64(node.Breakers.Parent.EstimatedSizeInBytes) /
-				float64(node.Breakers.Parent.LimitSizeInBytes) * 100
-			memoryPressurePoints += breakerPressure * 0.3
-			totalMemoryFactors += 30
-		}
-
-		// Indexing pressure memory contributes 30% of the memory pressure.
-		if node.IndexingPressure != nil && node.IndexingPressure.Memory != nil {
-			if pressure := node.IndexingPressure.Memory; pressure.Current != nil &&
-				pressure.LimitInBytes > 0 {
-				currentPressure := float64(pressure.Current.AllInBytes) /
-					float64(pressure.LimitInBytes) * 100
-				memoryPressurePoints += currentPressure * 0.3
-				totalMemoryFactors += 30
-			}
-		}
-
-		// Calculate write pressure based on:
-		// - Write load
-		// - Throttle status
-		// - Merge pressure
-		if node.Indices != nil {
-			// Write load contributes 50% of the write pressure.
-			if node.Indices.Indexing != nil && node.Indices.Indexing.WriteLoad > 0 {
-				// Normalize the write load (assume that >1 is 100% pressure).
-				writePressure := math.Min(node.Indices.Indexing.WriteLoad*100, 100)
-
-				writePressurePoints += writePressure * 0.5
-
-				totalWriteFactors += 50
-			}
-
-			// Merge status contributes 30% of the write pressure. It needs
-			// the JVM uptime as the denominator, so the factor is skipped
-			// when the JVM section is missing or uptime is 0.
-			if merges := node.Indices.Merges; merges != nil && merges.TotalTimeInMillis > 0 &&
-				node.JVM != nil && node.JVM.UptimeInMillis > 0 {
-				// If spending more than 10% of the time in merges, consider pressure.
-				mergePressure := math.Min(
-					float64(merges.TotalTimeInMillis)/
-						float64(node.JVM.UptimeInMillis)*1000, 100,
-				)
-
-				writePressurePoints += mergePressure * 0.3
-
-				totalWriteFactors += 30
-			}
-
-			// Throttle status contributes 20% of the write pressure.
-			if node.Indices.Indexing != nil && node.Indices.Indexing.IsThrottled {
-				writePressurePoints += 100 * 0.2
-
-				totalWriteFactors += 20
-			}
-		}
+		writePoints, writeFactors := nodeWritePressureFactors(node)
+		writePressurePoints += writePoints
+		totalWriteFactors += writeFactors
 	}
 
 	// Normalize the memory pressure.

--- a/utils_pressure_test.go
+++ b/utils_pressure_test.go
@@ -1,0 +1,290 @@
+package ebi
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin calculateSystemPressure against partially-populated node
+// stats. Elasticsearch omits whole sections (jvm, breakers,
+// indexing_pressure, indices.indexing, ...) depending on node role, version
+// and the requested metric filter — every pointer in NodeDetails can
+// legitimately be nil, and every limit can legitimately be 0. The function
+// must never panic and must never emit NaN/Inf pressure numbers: a single
+// poisoned node would silently corrupt the pause/refresh decisions for the
+// whole bulk run.
+
+// fullStatsNode returns a node with every section populated, chosen so the
+// expected pressure numbers are exact:
+//
+//	memory: heap 50%*0.4=20pts(+40) + breaker 50%*0.3=15pts(+30) +
+//	        indexing-pressure 10%*0.3=3pts(+30) => 38/100*100 = 38
+//	write:  writeLoad 0.5→50*0.5=25pts(+50) + merges 100/10000*1000=10*0.3=3pts(+30) +
+//	        throttled 100*0.2=20pts(+20) => 48/100*100 = 48
+//	overall: 38*0.6 + 48*0.4 = 42
+func fullStatsNode() *NodeDetails {
+	return &NodeDetails{
+		Roles: []string{"data", "master"},
+		JVM: &JVMStats{
+			UptimeInMillis: 10_000,
+			Mem: &JVMMemoryStats{
+				HeapUsedPercent: 50,
+				HeapMaxInBytes:  8 * 1024 * 1024 * 1024,
+			},
+		},
+		Breakers: &BreakerStats{
+			Parent: &BreakerDetails{
+				EstimatedSizeInBytes: 50,
+				LimitSizeInBytes:     100,
+			},
+		},
+		IndexingPressure: &IndexingPressureStats{
+			Memory: &IndexingPressureMemory{
+				Current:      &IndexingPressureMemoryUsage{AllInBytes: 10},
+				LimitInBytes: 100,
+			},
+		},
+		Indices: &IndicesStats{
+			Indexing: &IndexingStats{
+				WriteLoad:   0.5,
+				IsThrottled: true,
+			},
+			Merges: &MergesStats{
+				TotalTimeInMillis: 100,
+			},
+		},
+	}
+}
+
+//nolint:maintidx
+func TestCalculateSystemPressure_Table(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		nodes map[string]*NodeDetails
+
+		// Exact expectations; negative values mean "only assert sanity"
+		// (non-NaN, non-Inf, within 0..100).
+		wantMemory  float64
+		wantWrite   float64
+		wantOverall float64
+
+		wantNumDataNodes int
+		wantRAMPerNodeGB int
+	}{
+		{
+			name:             "full stats exact numbers",
+			nodes:            map[string]*NodeDetails{"n1": fullStatsNode()},
+			wantMemory:       38,
+			wantWrite:        48,
+			wantOverall:      42,
+			wantNumDataNodes: 1,
+			wantRAMPerNodeGB: 8,
+		},
+		{
+			name: "data-role node with nil JVM",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"data"},
+				JVM:   nil,
+			}},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 1,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "data-role node with nil JVM.Mem",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"data"},
+				JVM:   &JVMStats{UptimeInMillis: 1000, Mem: nil},
+			}},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 1,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "nil IndexingPressure section",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				JVM: &JVMStats{
+					UptimeInMillis: 1000,
+					Mem:            &JVMMemoryStats{HeapUsedPercent: 50},
+				},
+				IndexingPressure: nil,
+			}},
+			// Heap is the only factor: 20pts/40 => 50.
+			wantMemory:       50,
+			wantWrite:        0,
+			wantOverall:      30,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "IndexingPressure.Memory with nil Current",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				IndexingPressure: &IndexingPressureStats{
+					Memory: &IndexingPressureMemory{
+						Current:      nil,
+						LimitInBytes: 100,
+					},
+				},
+			}},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "Indices with nil Indexing",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				Indices: &IndicesStats{
+					Indexing: nil,
+				},
+			}},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "merges present but nil JVM",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				JVM:   nil,
+				Indices: &IndicesStats{
+					Indexing: &IndexingStats{},
+					Merges:   &MergesStats{TotalTimeInMillis: 500},
+				},
+			}},
+			// The merges factor needs JVM uptime as the denominator; with
+			// JVM absent it must be skipped, not divide by nil/zero.
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "merges present but zero JVM uptime",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				JVM:   &JVMStats{UptimeInMillis: 0},
+				Indices: &IndicesStats{
+					Indexing: &IndexingStats{},
+					Merges:   &MergesStats{TotalTimeInMillis: 500},
+				},
+			}},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "breaker LimitSizeInBytes zero",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				JVM: &JVMStats{
+					UptimeInMillis: 1000,
+					Mem:            &JVMMemoryStats{HeapUsedPercent: 50},
+				},
+				Breakers: &BreakerStats{
+					Parent: &BreakerDetails{
+						EstimatedSizeInBytes: 100,
+						LimitSizeInBytes:     0,
+					},
+				},
+			}},
+			// A zero breaker limit must be skipped: dividing by it yields
+			// +Inf which poisons every downstream pressure number. Heap is
+			// then the only factor: 50.
+			wantMemory:       50,
+			wantWrite:        0,
+			wantOverall:      30,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name: "indexing pressure LimitInBytes zero",
+			nodes: map[string]*NodeDetails{"n1": {
+				Roles: []string{"ingest"},
+				IndexingPressure: &IndexingPressureStats{
+					Memory: &IndexingPressureMemory{
+						Current:      &IndexingPressureMemoryUsage{AllInBytes: 10},
+						LimitInBytes: 0,
+					},
+				},
+			}},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			name:             "empty nodes map",
+			nodes:            map[string]*NodeDetails{},
+			wantMemory:       0,
+			wantWrite:        0,
+			wantOverall:      0,
+			wantNumDataNodes: 0,
+			wantRAMPerNodeGB: 0,
+		},
+		{
+			// A `"nodes": {"x": null}` payload decodes into a nil entry.
+			name:             "nil node entry",
+			nodes:            map[string]*NodeDetails{"n1": nil, "n2": fullStatsNode()},
+			wantMemory:       38,
+			wantWrite:        48,
+			wantOverall:      42,
+			wantNumDataNodes: 1,
+			wantRAMPerNodeGB: 8,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			metrics, err := NewMetrics()
+			require.NoError(t, err)
+
+			// Must be panic-free for every partially-populated shape.
+			require.NotPanics(t, func() {
+				calculateSystemPressure(metrics, NodesStats{Nodes: tc.nodes})
+			}, "calculateSystemPressure must not panic on partially-populated node stats")
+
+			got := metrics.GetMetrics()
+
+			// Sanity for every case: no NaN/Inf, all pressures in 0..100.
+			for name, v := range map[string]float64{
+				"MemoryPressure":  got.MemoryPressure,
+				"WritePressure":   got.WritePressure,
+				"OverallPressure": got.OverallPressure,
+			} {
+				assert.False(t, math.IsNaN(v), "%s must not be NaN", name)
+				assert.False(t, math.IsInf(v, 0), "%s must not be Inf", name)
+				assert.GreaterOrEqual(t, v, 0.0, "%s must be >= 0", name)
+				assert.LessOrEqual(t, v, 100.0, "%s must be <= 100", name)
+			}
+
+			assert.InDelta(t, tc.wantMemory, got.MemoryPressure, 1e-9, "MemoryPressure")
+			assert.InDelta(t, tc.wantWrite, got.WritePressure, 1e-9, "WritePressure")
+			assert.InDelta(t, tc.wantOverall, got.OverallPressure, 1e-9, "OverallPressure")
+
+			assert.Equal(t, tc.wantNumDataNodes, got.numDataNodes, "numDataNodes")
+			assert.Equal(t, tc.wantRAMPerNodeGB, got.ramPerNodeGB, "ramPerNodeGB")
+		})
+	}
+}

--- a/utils_pressure_test.go
+++ b/utils_pressure_test.go
@@ -59,7 +59,6 @@ func fullStatsNode() *NodeDetails {
 	}
 }
 
-//nolint:maintidx
 func TestCalculateSystemPressure_Table(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Full audit of the library (independent concurrency + correctness passes, cross-checked adversarially) surfaced 14 confirmed bug groups. This PR fixes all of them and adds a regression suite (~1.4k lines) covering happy paths, bad paths, edge cases, deadlock/race regressions, and end-to-end flows against a request-capturing fake ES server.

### Deadlocks / leaks (critical)
- `defer`red `MetricsCh` sends inside the docs loop and the metrics-goroutine tick loop accumulated (one per doc / per tick) and fired as blocking sends at return/exit — hanging BulkCreate's epilogue or re-leaking the metrics goroutine the previous fix addressed. Removed; every MetricsCh delivery is now a non-blocking best-effort send.
- Unguarded blocking `MetricsCh` sends in esutil worker callbacks (OnSuccess/OnFailure/OnError) could stall workers so `bi.Close` never drained.
- `asyncErrorHandler` and the metrics goroutine's ES calls now bind to the internal `metricsCtx`, so BulkCreate's return unblocks parked error sends even with a Background-like caller ctx.

### Wrong results (critical)
- `bi.Stats()` was read **before** the deferred `bi.Close` performed the final flush — failures in that flush never surfaced and BulkCreate returned `nil` despite failed documents. Close (once) now happens before the stats check.
- `WithDocAsUpsert(false)` was impossible: NewBulkOptions dropped the value and the `default:"true"` tag flipped it back — update-only operations silently upserted.

### Data races
- Live `*Metrics` pointer was sent over MetricsCh and passed to PauseFunc/RefreshFunc while writers kept mutating it; receivers now get `GetMetrics()` snapshots.
- `numDataNodes`, `ramPerNodeGB`, `NodeStats` were written without the mutex that readers hold; now behind locked setters.
- BulkCreate mutated caller-owned opts (`Index`, `BatchSize`, `NumWorkers`, `FlushBytes`): concurrent calls sharing opts raced, and sequential reuse compounded IndexNameFunc suffixes (HyperparameterOptimization hit this every iteration). opts is now read-only; all derived values are locals.

### Panics
- `calculateSystemPressure` nil-derefs (JVM, JVM.Mem, IndexingPressure, Current, Indices.Indexing, nil node entries) and div-by-zero → Inf/NaN pressure (breaker/pressure limits, uptime).
- Integer divide-by-zero on empty-but-non-nil SampleDoc reaching BulkCreate via struct literals.

### Dead / broken options
- `RefreshPolicy` (immediate→"true" mapping), `FlushStartFunc`, `FlushEndFunc` now wired into esutil; caller-set `FlushBytes` honored; `BatchSize` now drives flush cadence (was computed and wired to nothing); `RetryOnFailure` documented as reserved/unwired.
- `res.IsError()` now checked on nodes-stats and Ping (error payloads decoded into zero stats / yielded a "working" client).

## Test plan
- Every fix has a regression test that **failed against main** for the right reason before the fix (deadlock tests guarded by 10s timeouts; race tests trip `-race` pre-fix).
- `go test -race -count=1 ./...` green (10+ consecutive runs), `go vet` clean, all pre-existing tests pass unmodified.